### PR TITLE
setup.py: always add include files directory for SWIG

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ class PkgConfigNeededExtension(Extension):
         if not self.pkg_config_cflags:
             return []
         return shlex.split(
-            check_output(["pkg-config", "--cflags"] + self.pkg_config_cflags).decode()
+            check_output(["pkg-config", "--cflags"] + self.pkg_config_cflags,
+                env=dict(os.environ, PKG_CONFIG_ALLOW_SYSTEM_CFLAGS="1")).decode()
         )
 
     @property


### PR DESCRIPTION
When tpm2-tss is installed to the standard include files directory `/usr/include`, `pkg-config --cflags` filters out this system directory, leading to an empty output. SWIG on the other hand does not search `/usr/include` by default, which leads to the error
```
swig -python -py3 -outdir tpm2_pytss -o tpm2_pytss/swig/esys_binding_wrap.c tpm2_pytss/swig/esys_binding.i
tpm2_pytss/swig/tpm2_types.i:8: Error: Unable to find 'tss2/tss2_common.h'
tpm2_pytss/swig/tpm2_types.i:9: Error: Unable to find 'tss2/tss2_tpm2_types.h'
error: command 'swig' failed with exit status 1
```
Setting the environment variable `PKG_CONFIG_ALLOW_SYSTEM_CFLAGS` disables the filtering, thus adding the required `-I/usr/include` to the SWIG call.