### PR TITLE
MANIFEST: distribute examples

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include tpm2_pytss/version
 include tpm2_pytss/config.json
 recursive-include tpm2_pytss/swig *
 recursive-include tests *
+recursive-include examples *


### PR DESCRIPTION
[`examples/fapi_get_random.py`](https://github.com/tpm2-software/tpm2-pytss/blob/master/examples/fapi_get_random.py) is required by [`tests/test_examples.py`](https://github.com/tpm2-software/tpm2-pytss/blob/master/tests/test_examples.py) and might be helpful for users as well. Examples are only included in the distribution and not installed by Python.