### PR TITLE
tests: use ek_cert_less for mssim FAPI tests for tpm2-tss 2.4.1

### DIFF
--- a/.ci/download-deps.sh
+++ b/.ci/download-deps.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
 
-# TPM2 2.4.0
-export TPM2_TSS_SHA=70da4f245a575948712a7c2cf52de84213dc9db8
+# TPM2 2.4.1
+export TPM2_TSS_SHA=703a16f288bc1119a07425d36e80a3004cbe5210
 
 function get_deps() {
 

--- a/examples/fapi_get_random.py
+++ b/examples/fapi_get_random.py
@@ -24,6 +24,7 @@ def main():
                 log_dir=log_dir,
                 tcti="mssim:port=%d" % (simulator.port,),
                 tcti_retry=100,
+                ek_cert_less=1,
             )
         )
         # Enter the context, create TCTI connection

--- a/tpm2_pytss/util/testing.py
+++ b/tpm2_pytss/util/testing.py
@@ -67,6 +67,7 @@ class BaseTestFAPI(SimulatorTest, unittest.TestCase):
                 log_dir=self.log_dir,
                 tcti="mssim:port=%d" % (self.simulator.port,),
                 tcti_retry=TCTI_RETRY_TRIES,
+                ek_cert_less=1,
             )
         )
         # Enter the context


### PR DESCRIPTION
Since upstream commit https://github.com/tpm2-software/tpm2-tss/commit/e974a73b087c8889a3d138b09fbe71031ed9f8b8 it is necessary to use `ek_cert_less` when testing with the TPM simulator since the EK is now used as a session key by default and the TPM simulator does not provide an EK certificate.