### PR TITLE
Fix return type for uint8_t array

### DIFF
--- a/tpm2_pytss/context.py
+++ b/tpm2_pytss/context.py
@@ -141,7 +141,7 @@ class BaseContextMetaClass(type):
                                 and "uint8_t" in docstring.split()
                             ):
                                 return_value.append(
-                                    to_bytearray(value.value, args[i + 1].value)
+                                    to_bytearray(args[i + 1].value, value.value)
                                 )
                                 skip = True
                                 continue


### PR DESCRIPTION
For return types which consist of `uint8_t*` and `size_t`, the `to_bytearray` arguments need to be swapped.

To verify this, issue a FAPI`PcrRead` command
```python
            with UINT8_PTR_PTR() as pcrValue:
                with SIZE_T_PTR() as pcrValueSize:
                    with CHAR_PTR_PTR() as pcrLog:
                        pcrValue, pcrLog = fapi_ctx.PcrRead(0, pcrValue, pcrValueSize, pcrLog)
                        print(str(pcrValue))
```