### PR TITLE
refactor: No context managers

### DIFF
--- a/examples/fapi_get_random.py
+++ b/examples/fapi_get_random.py
@@ -43,10 +43,8 @@ def main():
         fapi_ctx = ctx_stack.enter_context(fapi)
         # Call Fapi_Provision
         fapi_ctx.Provision(None, None, None)
-        # Create a pointer to the byte array we'll get back from GetRandom
-        array = ctx_stack.enter_context(UINT8_PTR_PTR())
         # Call GetRandom and convert the resulting array to a Python bytearray
-        value = to_bytearray(length, fapi_ctx.GetRandom(length, array))
+        value = to_bytearray(length, fapi_ctx.GetRandom(length))
         # Ensure we got the correct number of bytes
         if length != len(value):
             raise AssertionError("Requested %d bytes, got %d" % (length, len(value)))

--- a/tests/test_esys_audit.py
+++ b/tests/test_esys_audit.py
@@ -2,6 +2,7 @@ from contextlib import ExitStack
 
 from tpm2_pytss.binding import *
 from tpm2_pytss.util.testing import BaseTestESYS
+from tpm2_pytss.exceptions import TPM2Error
 
 
 class TestAudit(BaseTestESYS):
@@ -60,36 +61,25 @@ class TestAudit(BaseTestESYS):
 
             creationPCR = TPML_PCR_SELECTION(count=0)
 
-            authValue_ptr = stack.enter_context(authValue.ptr())
-
-            self.esys_ctx.TR_SetAuth(ESYS_TR_RH_OWNER, authValue_ptr)
-
-            inSensitivePrimary_ptr = stack.enter_context(inSensitivePrimary.ptr())
-            inPublic_ptr = stack.enter_context(inPublic.ptr())
-            outsideInfo_ptr = stack.enter_context(outsideInfo.ptr())
-            creationPCR_ptr = stack.enter_context(creationPCR.ptr())
-            primaryHandle_node_ptr_ptr = stack.enter_context(ESYS_TR_PTR_PTR())
-            outPublic_ptr_ptr = stack.enter_context(TPM2B_PUBLIC_PTR_PTR())
-            creationData_ptr_ptr = stack.enter_context(TPM2B_CREATION_DATA_PTR_PTR())
-            creationHash_ptr_ptr = stack.enter_context(TPM2B_DIGEST_PTR_PTR())
-            creationTicket_ptr_ptr = stack.enter_context(TPMT_TK_CREATION_PTR_PTR())
+            self.esys_ctx.TR_SetAuth(ESYS_TR_RH_OWNER, authValue)
 
             signHandle = stack.enter_context(self.esys_ctx.flush_tr())
 
-            self.esys_ctx.CreatePrimary(
+            (
+                outPublic,
+                creationData,
+                creationHash,
+                creationTicket,
+            ) = self.esys_ctx.CreatePrimary(
                 ESYS_TR_RH_OWNER,
                 ESYS_TR_PASSWORD,
                 ESYS_TR_NONE,
                 ESYS_TR_NONE,
-                inSensitivePrimary_ptr,
-                inPublic_ptr,
-                outsideInfo_ptr,
-                creationPCR_ptr,
+                inSensitivePrimary,
+                inPublic,
+                outsideInfo,
+                creationPCR,
                 signHandle,
-                outPublic_ptr_ptr,
-                creationData_ptr_ptr,
-                creationHash_ptr_ptr,
-                creationTicket_ptr_ptr,
             )
 
             # /* Start a audit session */
@@ -97,8 +87,6 @@ class TestAudit(BaseTestESYS):
             sessionType = TPM2_SE_HMAC
             authHash = TPM2_ALG_SHA256
             symmetric = TPMT_SYM_DEF(algorithm=TPM2_ALG_NULL)
-
-            symmetric_ptr = stack.enter_context(symmetric.ptr())
 
             session = stack.enter_context(
                 self.esys_ctx.auth_session(
@@ -109,7 +97,7 @@ class TestAudit(BaseTestESYS):
                     ESYS_TR_NONE,
                     None,
                     sessionType,
-                    symmetric_ptr,
+                    symmetric,
                     authHash,
                 )
             )
@@ -121,11 +109,11 @@ class TestAudit(BaseTestESYS):
             prop = TPM2_PT_LOCKOUT_COUNTER
             propertyCount = 1
 
-            moreData_ptr = stack.enter_context(TPMI_YES_NO_PTR(False))
+            moreData_ptr = TPMI_YES_NO_PTR(False)
 
-            capabilityData_ptr_ptr = stack.enter_context(TPMS_CAPABILITY_DATA_PTR_PTR())
+            capabilityData_ptr = TPMS_CAPABILITY_DATA_PTR()
 
-            self.esys_ctx.GetCapability(
+            capabilityData_ptr_ptr = self.esys_ctx.GetCapability(
                 session,
                 ESYS_TR_NONE,
                 ESYS_TR_NONE,
@@ -133,49 +121,45 @@ class TestAudit(BaseTestESYS):
                 prop,
                 propertyCount,
                 moreData_ptr,
-                capabilityData_ptr_ptr,
             )
 
             privacyHandle = ESYS_TR_RH_ENDORSEMENT
             qualifyingData = TPM2B_DATA(length=0, buffer=[])
             inScheme = TPMT_SIG_SCHEME(scheme=TPM2_ALG_NULL)
 
-            qualifyingData_ptr = stack.enter_context(qualifyingData.ptr())
-            inScheme_ptr = stack.enter_context(inScheme.ptr())
-            auditInfo_ptr_ptr = stack.enter_context(TPM2B_ATTEST_PTR_PTR())
-            signature_ptr_ptr = stack.enter_context(TPMT_SIGNATURE_PTR_PTR())
-
             # Test the audit commands
-            r = self.esys_ctx.GetCommandAuditDigest(
-                privacyHandle,
-                signHandle,
-                ESYS_TR_PASSWORD,
-                ESYS_TR_PASSWORD,
-                ESYS_TR_NONE,
-                qualifyingData_ptr,
-                inScheme_ptr,
-                auditInfo_ptr_ptr,
-                signature_ptr_ptr,
-            )
-
-            if (
-                (r == TPM2_RC_COMMAND_CODE)
-                or (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER))
-                or (r == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER))
-            ):
-                self.skipTest(
-                    "Command TPM2_GetCommandAuditDigest not supported by TPM."
+            try:
+                (
+                    auditInfo_ptr_ptr,
+                    signature_ptr_ptr,
+                ) = self.esys_ctx.GetCommandAuditDigest(
+                    privacyHandle,
+                    signHandle,
+                    ESYS_TR_PASSWORD,
+                    ESYS_TR_PASSWORD,
+                    ESYS_TR_NONE,
+                    qualifyingData,
+                    inScheme,
                 )
+            except TPM2Error as error:
+                if (
+                    (error.rc == TPM2_RC_COMMAND_CODE)
+                    or (error.rc == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER))
+                    or (error.rc == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER))
+                ):
+                    self.skipTest(
+                        "Command TPM2_GetCommandAuditDigest not supported by TPM."
+                    )
 
-            r = self.esys_ctx.GetSessionAuditDigest(
+            self.esys_ctx.GetSessionAuditDigest(
                 privacyHandle,
                 signHandle,
                 session,
                 ESYS_TR_PASSWORD,
                 ESYS_TR_PASSWORD,
                 ESYS_TR_NONE,
-                qualifyingData_ptr,
-                inScheme_ptr,
+                qualifyingData,
+                inScheme,
                 auditInfo_ptr_ptr,
                 signature_ptr_ptr,
             )
@@ -184,19 +168,17 @@ class TestAudit(BaseTestESYS):
             clearList = TPML_CC()
             setList = TPML_CC()
 
-            setList_ptr = stack.enter_context(setList.ptr())
-            clearList_ptr = stack.enter_context(clearList.ptr())
-
-            r = self.esys_ctx.SetCommandCodeAuditStatus(
-                ESYS_TR_RH_PLATFORM,
-                ESYS_TR_PASSWORD,
-                ESYS_TR_NONE,
-                ESYS_TR_NONE,
-                auditAlg,
-                setList_ptr,
-                clearList_ptr,
-            )
-
-            if (r & ~TPM2_RC_N_MASK) == TPM2_RC_BAD_AUTH:
-                # Platform authorization not possible test will be skipped
-                self.skipTest("Platform authorization not possible.")
+            try:
+                self.esys_ctx.SetCommandCodeAuditStatus(
+                    ESYS_TR_RH_PLATFORM,
+                    ESYS_TR_PASSWORD,
+                    ESYS_TR_NONE,
+                    ESYS_TR_NONE,
+                    auditAlg,
+                    clearList,
+                    setList,
+                )
+            except TPM2Error as error:
+                if (error.rc & ~TPM2_RC_N_MASK) == TPM2_RC_BAD_AUTH:
+                    # Platform authorization not possible test will be skipped
+                    self.skipTest("Platform authorization not possible.")

--- a/tests/test_esys_audit.py
+++ b/tests/test_esys_audit.py
@@ -150,6 +150,7 @@ class TestAudit(BaseTestESYS):
                     self.skipTest(
                         "Command TPM2_GetCommandAuditDigest not supported by TPM."
                     )
+                raise
 
             self.esys_ctx.GetSessionAuditDigest(
                 privacyHandle,
@@ -182,3 +183,4 @@ class TestAudit(BaseTestESYS):
                 if (error.rc & ~TPM2_RC_N_MASK) == TPM2_RC_BAD_AUTH:
                     # Platform authorization not possible test will be skipped
                     self.skipTest("Platform authorization not possible.")
+                raise

--- a/tests/test_esys_get_capability.py
+++ b/tests/test_esys_get_capability.py
@@ -8,16 +8,6 @@ class TestGetCapability(BaseTestESYS):
         prop = TPM2_PT_LOCKOUT_COUNTER
         propertyCount = 1
 
-        with TPMI_YES_NO_PTR(
-            False
-        ) as moreData_ptr, TPMS_CAPABILITY_DATA_PTR_PTR() as capabilityData_ptr_ptr:
-            r = self.esys_ctx.GetCapability(
-                ESYS_TR_NONE,
-                ESYS_TR_NONE,
-                ESYS_TR_NONE,
-                capability,
-                prop,
-                propertyCount,
-                moreData_ptr,
-                capabilityData_ptr_ptr,
-            )
+        self.esys_ctx.GetCapability(
+            ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, capability, prop, propertyCount,
+        )

--- a/tests/test_esys_get_random.py
+++ b/tests/test_esys_get_random.py
@@ -27,8 +27,6 @@ class TestGetRandom(BaseTestESYS):
                 mode=TPMU_SYM_MODE(aes=TPM2_ALG_CFB),
             )
 
-            symmetric_ptr = stack.enter_context(symmetric.ptr())
-
             session = stack.enter_context(
                 self.esys_ctx.auth_session(
                     ESYS_TR_NONE,
@@ -38,7 +36,7 @@ class TestGetRandom(BaseTestESYS):
                     ESYS_TR_NONE,
                     None,
                     TPM2_SE_HMAC,
-                    symmetric_ptr,
+                    symmetric,
                     TPM2_ALG_SHA1,
                 )
             )

--- a/tests/test_esys_load_external.py
+++ b/tests/test_esys_load_external.py
@@ -68,7 +68,6 @@ class TestLoadExternal(BaseTestESYS):
                 ),
             )
 
-            in_public_ptr = stack.enter_context(in_public.ptr())
             object_handle = stack.enter_context(self.esys_ctx.flush_tr())
 
             self.esys_ctx.LoadExternal(
@@ -76,7 +75,7 @@ class TestLoadExternal(BaseTestESYS):
                 ESYS_TR_NONE,
                 ESYS_TR_NONE,
                 None,
-                in_public_ptr,
+                in_public,
                 TPM2_RH_OWNER,
                 object_handle,
             )

--- a/tests/test_fapi_get_random.py
+++ b/tests/test_fapi_get_random.py
@@ -16,9 +16,8 @@ class TestGetRandom(BaseTestFAPI):
 
         self.fapi_ctx.Provision(None, None, None)
 
-        with UINT8_PTR_PTR() as array:
-            array = self.fapi_ctx.GetRandom(length, array)
+        array = self.fapi_ctx.GetRandom(length)
 
-            value = to_bytearray(length, array)
+        value = to_bytearray(length, array)
 
-            self.assertEqual(length, len(value))
+        self.assertEqual(length, len(value))

--- a/tests/test_fapi_get_random.py
+++ b/tests/test_fapi_get_random.py
@@ -9,8 +9,7 @@ class TestGetRandom(BaseTestFAPI):
     def test_get_info(self):
         self.fapi_ctx.Provision(None, None, None)
 
-        with CHAR_PTR_PTR() as array:
-            self.assertEqual(type(self.fapi_ctx.GetInfo(array)), dict)
+        self.assertEqual(type(self.fapi_ctx.GetInfo()), dict)
 
     def test_random_length(self):
         length = random.randint(8, 32)

--- a/tests/test_tcti.py
+++ b/tests/test_tcti.py
@@ -1,0 +1,22 @@
+import unittest
+
+from tpm2_pytss.tcti import TCTI
+from tpm2_pytss.util.simulator import SimulatorTest
+
+
+class TestTCTI(unittest.TestCase):
+    def test_load(self):
+        name = "mssim"
+        tcti = TCTI.load(name)
+        with self.subTest(check_name=1):
+            self.assertEqual(tcti.NAME, name)
+            self.assertEqual(tcti.CONTEXT.NAME, name)
+            self.assertEqual(tcti.__class__.__qualname__, name.title() + "TCTI")
+            self.assertEqual(tcti.CONTEXT.__qualname__, name.title() + "TCTIContext")
+
+
+class TestTCTIContext(SimulatorTest, unittest.TestCase):
+    def test_create_context(self):
+        tcti = TCTI.load("mssim")
+        with tcti(f"port={self.simulator.port}") as ctx:
+            pass

--- a/tests/test_tcti.py
+++ b/tests/test_tcti.py
@@ -18,5 +18,5 @@ class TestTCTI(unittest.TestCase):
 class TestTCTIContext(SimulatorTest, unittest.TestCase):
     def test_create_context(self):
         tcti = TCTI.load("mssim")
-        with tcti(f"port={self.simulator.port}") as ctx:
+        with tcti(config=f"port={self.simulator.port}") as ctx:
             pass

--- a/tpm2_pytss/binding.py
+++ b/tpm2_pytss/binding.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager, _GeneratorContextManager
 from typing import Any, Callable, Optional, List
 
 from . import exceptions
-from .util.swig import WrapperMetaClass, pointer_class, ContextManagedPointerClass
+from .util.swig import WrapperMetaClass, pointer_class, PointerClass
 from .util.calculate import calculate
 from .esys_binding import *
 from .fapi_binding import *
@@ -423,13 +423,13 @@ class UsedWithoutEnteringContext(Exception):
 def call_mod_context_managed_pointer_class(name, annotation, value):
     if isinstance(value, _GeneratorContextManager):
         raise UsedWithoutEnteringContext(name)
-    if isinstance(value, ContextManagedPointerClass):
+    if isinstance(value, PointerClass):
         if value.ptr is None:
             raise UsedWithoutEnteringContext(name)
         return WrapperMetaClass.call_mod_ptr_or_value(annotation, value)
 
 
-# Create all the ContextManagedPointerClasses to be used for the
+# Create all the PointerClasses to be used for the
 # pointer_functions
 for module in [esys_binding, fapi_binding]:
     for name, func in inspect.getmembers(module):

--- a/tpm2_pytss/context.py
+++ b/tpm2_pytss/context.py
@@ -109,12 +109,12 @@ def wrap_pass_ctxp(ctx, func):
                 docstring_arguments
             ):
                 for i, docstring in enumerate(docstring_arguments[len(args) :]):
-                    cls_name = (
-                        docstring.split()[0]
-                        + "_"
-                        + "_".join(["PTR"] * docstring.count("*"))
-                    )
-                    arg_cls = getattr(ctx.MODULE, cls_name)
+                    cls_name = docstring.split()[0]
+                    # Handle uintN_t
+                    if cls_name.endswith("_t"):
+                        cls_name = cls_name[:-2]
+                    cls_name = cls_name + "_" + "_".join(["PTR"] * docstring.count("*"))
+                    arg_cls = getattr(ctx.MODULE, cls_name.upper())
                     arg = arg_cls()
                     args.append(arg)
 

--- a/tpm2_pytss/esys.py
+++ b/tpm2_pytss/esys.py
@@ -98,10 +98,9 @@ class ESYSContext(Wrapper, metaclass=ESYSContextMetaClass):
                 "Maximum length is {}".format(self.GET_RANDOM_MAX_LENGTH)
             )
 
-        with self.TPM2B_DIGEST_PTR_PTR() as datapp:
-            self.GetRandom(shandle1, shandle2, shandle3, length, datapp)
+        datapp = self.GetRandom(shandle1, shandle2, shandle3, length)
 
-            return self._bytearray(datapp.value.size, datapp.value.buffer)
+        return self._bytearray(datapp.size, datapp.buffer)
 
 
 class ESYS(Wrapper):


### PR DESCRIPTION
I made a bad decision when going with context managers. My paranoia that things wouldn't get free'd was, well, too much paranoia for that. This patchset uses `__del__`, which is a sane approach.

This patchset also includes auto allocating of arguments which hold return values