### PR TITLE
Fix size_t pointer args

### DIFF
--- a/tpm2_pytss/context.py
+++ b/tpm2_pytss/context.py
@@ -164,9 +164,12 @@ def wrap_pass_ctxp(ctx, func):
                             and "*" in next_docstring
                             and "uint8_t" in docstring.split()
                         ):
-                            return_value.append(
-                                to_bytearray(value.value, args[i + 1].value)
-                            )
+                            if value and value.value:
+                                return_value.append(
+                                    to_bytearray(args[i + 1].value, value.value)
+                                )
+                            else:
+                                return_value.append(None)
                             skip = True
                             continue
                     return_value.append(value.value)

--- a/tpm2_pytss/context.py
+++ b/tpm2_pytss/context.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2019 Intel Corporation
+import re
 import json
 import inspect
 import contextlib
@@ -111,7 +112,7 @@ def wrap_pass_ctxp(ctx, func):
                 for i, docstring in enumerate(docstring_arguments[len(args) :]):
                     cls_name = docstring.split()[0]
                     # Handle uintN_t
-                    if cls_name.endswith("_t"):
+                    if re.search("\d+_t", cls_name):
                         cls_name = cls_name[:-2]
                     cls_name = cls_name + "_" + "_".join(["PTR"] * docstring.count("*"))
                     arg_cls = getattr(ctx.MODULE, cls_name.upper())


### PR DESCRIPTION
Fix two issues.

A) context.py handles function input parameters.
`UINT<n>_T` are special because for their pointer type `UINT<n>_PTR`, the __T_
suffix is omitted. That's not the case with all other types, including
`SIZE_T`, the pointer type of which is _SIZE_T_PTR_.
    
context.py accounts for the `uint<n>_t` special case. However, this code
path is also matches for _size_t_ types, treating them as a special case,
too, when they are in fact not.

B) In some cases, when NULL/None is returned, a cast to a byte array fails. Add a check.
