### PR TITLE
Fix tpml digest binding

### DIFF
--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -5,6 +5,7 @@ from tpm2_pytss.binding import *
 
 class TestBinding(unittest.TestCase):
     def test_set_array(self):
+        # TPML_PCR_SELECTION
         sel = TPMS_PCR_SELECTION(
             hash=TPM2_ALG_SHA256, sizeofSelect=3, pcrSelect=(0, 0, 255)
         )
@@ -12,3 +13,9 @@ class TestBinding(unittest.TestCase):
         TPMS_PCR_SELECTION(hash=TPM2_ALG_SHA256, sizeofSelect=3, pcrSelect=(0, 0, 255))
 
         sels = TPML_PCR_SELECTION(count=1, pcrSelections=(sel,))
+
+        # TPML_DIGEST
+        dig1 = TPM2B_DIGEST(size=32, buffer=bytes(range(32)))
+        dig2 = TPM2B_DIGEST(size=32, buffer=bytes(range(1, 33)))
+
+        digs = TPML_DIGEST(count=2, digests=[dig1, dig2,])

--- a/tpm2_pytss/binding.py
+++ b/tpm2_pytss/binding.py
@@ -148,7 +148,7 @@ class ByteArrayHelper:
                 # Skip if not a python type
                 if not isinstance(kwargs[buffer_prop], (tuple, list, bytes, bytearray)):
                     continue
-                if buffer_prop == "pcrSelections":
+                if buffer_prop in ["pcrSelections", "digests"]:
                     continue
                 # Add to buffers to be converted
                 convert_buffer[buffer_prop] = kwargs[buffer_prop]

--- a/tpm2_pytss/config.json
+++ b/tpm2_pytss/config.json
@@ -1,3 +1,3 @@
 {
-    "sysconfdir": "/etc"
+    "sysconfdir": "/usr/local/etc"
 }

--- a/tpm2_pytss/config.json
+++ b/tpm2_pytss/config.json
@@ -1,3 +1,3 @@
 {
-    "sysconfdir": "/usr/local/etc"
+    "sysconfdir": "/etc"
 }


### PR DESCRIPTION
Fix the TPML_DIGEST type binding on the ByteArrayHelper and added test of the binding.

Also fixed the location of the sysconfig dir provided to the package to match the one in the docker image. Otherwise the procedure described in HACKING.md wasn't working.