### PR TITLE
Use pkgconfig to discover include paths

### DIFF
--- a/scripts/libtss2_build.py
+++ b/scripts/libtss2_build.py
@@ -48,9 +48,8 @@ ffibuilder.set_source(
      #include <tss2/tss2_tctildr.h>
      #include <tss2/tss2_fapi.h>
 """,
-    debug=True,
     libraries=["tss2-esys", "tss2-tctildr", "tss2-fapi"],
 )  # library name, for the linker
 
 if __name__ == "__main__":
-    ffibuilder.compile(verbose=True)
+    ffibuilder.compile(verbose=True, debug=True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ packages = find:
 setup_requires =
     setuptools_scm[toml]>=3.4.3
     cffi>=1.0.0
+    pkgconfig
 install_requires =
     cffi>=1.0.0
 


### PR DESCRIPTION
Use `pkgconfig` to get the include paths for the libraries. This also works for manually installed libraries (`/usr/local`).

Also, the build script `libtss2_build.py` gave me a TypeError, so I had to move the `debug=True`

I was not to sure how to add `pkgconfig` as a dependency. Would that be in `.ci/Dockerfile.tpm2-tss-python` or `.ci/download-deps.sh`?

**NOTE**: This PR sits on top of #58.