### PR TITLE
esapi: don't assume caller is providing TCTI context.

### DIFF
--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -10,10 +10,12 @@ from .utils import _chkrc, TPM2B_pack, TPM2B_unpack
 
 
 class ESAPI:
-    def __init__(self, tcti=ffi.NULL):
+    def __init__(self, tcti=None):
+
+        tctx = ffi.NULL if tcti is None else tcti.ctx
 
         self.ctx_pp = ffi.new("ESYS_CONTEXT **")
-        _chkrc(lib.Esys_Initialize(self.ctx_pp, tcti.ctx, ffi.NULL))
+        _chkrc(lib.Esys_Initialize(self.ctx_pp, tctx, ffi.NULL))
         self.ctx = self.ctx_pp[0]
 
     def __enter__(self):

--- a/tpm2_pytss/TctiLdr.py
+++ b/tpm2_pytss/TctiLdr.py
@@ -10,7 +10,7 @@ from .utils import _chkrc
 class TctiLdr:
     def __init__(self, name=None, conf=None):
 
-        self.ctx_pp = ffi.new("TSS2_TCTI_CONTEXT **")
+        self._ctx_pp = ffi.new("TSS2_TCTI_CONTEXT **")
 
         if name is None:
             name = ffi.NULL
@@ -28,8 +28,8 @@ class TctiLdr:
         if not isinstance(conf, (bytes, type(ffi.NULL))):
             raise RuntimeError(f"name must be of type bytes, got {type(name)}")
 
-        _chkrc(lib.Tss2_TctiLdr_Initialize_Ex(name, conf, self.ctx_pp))
-        self.ctx = self.ctx_pp[0]
+        _chkrc(lib.Tss2_TctiLdr_Initialize_Ex(name, conf, self._ctx_pp))
+        self._ctx = self._ctx_pp[0]
 
     def __enter__(self):
         return self
@@ -38,5 +38,9 @@ class TctiLdr:
         self.close()
 
     def close(self):
-        lib.Tss2_TctiLdr_Finalize(self.ctx_pp)
-        self.ctx = ffi.NULL
+        lib.Tss2_TctiLdr_Finalize(self._ctx_pp)
+        self._ctx = ffi.NULL
+
+    @property
+    def ctx(self):
+        return self._ctx


### PR DESCRIPTION
With this ectx = ESAPI() works