### PR TITLE
build: use PKG_CONFIG_ALLOW_SYSTEM_CFLAGS for pkgconfig

### DIFF
--- a/scripts/libtss2_build.py
+++ b/scripts/libtss2_build.py
@@ -17,6 +17,7 @@ def get_include_paths(library_names):
 
     # for manually installed packages, env var PKG_CONFIG_PATH might need to be changed
     for library_name in library_names:
+        os.environ["PKG_CONFIG_ALLOW_SYSTEM_CFLAGS"] = "1"
         cflags = pkgconfig.cflags(library_name)
         header_dirs.update(re.findall(r"(?<=-I)\S+", cflags))
 


### PR DESCRIPTION
When tpm2-tss is installed to the standard include files directory `/usr/include`, `pkgconfig.cflags()` filters out this system directory by default, leading to the following error:
```
Could not find esys headers in {'/usr/include/json-c', '/usr/include/tss2'}
```
Setting the environment variable `PKG_CONFIG_ALLOW_SYSTEM_CFLAGS` disables the filtering and makes the build pass.

This is the equivalent of PR #3 from before the CFFI rewrite.