### PR TITLE
utils: parse TSS2 return code in exception

### DIFF
--- a/test/test_exception.py
+++ b/test/test_exception.py
@@ -1,0 +1,40 @@
+import unittest
+
+from tpm2_pytss import TSS2_Exception, TPM2_RC
+
+
+class ExceptionTest(unittest.TestCase):
+    def test_non_fmt1(self):
+        exc = TSS2_Exception(TPM2_RC.SESSION_HANDLES)
+        self.assertEqual(exc.rc, TPM2_RC.SESSION_HANDLES)
+        self.assertEqual(exc.error, TPM2_RC.SESSION_HANDLES)
+        self.assertEqual(exc.handle, 0)
+        self.assertEqual(exc.parameter, 0)
+        self.assertEqual(exc.session, 0)
+
+    def test_handle(self):
+        rc = TPM2_RC.TYPE + TPM2_RC.H + TPM2_RC.RC1
+        exc = TSS2_Exception(rc)
+        self.assertEqual(exc.rc, rc)
+        self.assertEqual(exc.error, TPM2_RC.TYPE)
+        self.assertEqual(exc.handle, 1)
+        self.assertEqual(exc.parameter, 0)
+        self.assertEqual(exc.session, 0)
+
+    def test_parameter(self):
+        rc = TPM2_RC.ATTRIBUTES + TPM2_RC.P + TPM2_RC.RC1
+        exc = TSS2_Exception(rc)
+        self.assertEqual(exc.rc, rc)
+        self.assertEqual(exc.error, TPM2_RC.ATTRIBUTES)
+        self.assertEqual(exc.handle, 0)
+        self.assertEqual(exc.parameter, 1)
+        self.assertEqual(exc.session, 0)
+
+    def test_session(self):
+        rc = TPM2_RC.EXPIRED + TPM2_RC.S + TPM2_RC.RC1
+        exc = TSS2_Exception(rc)
+        self.assertEqual(exc.rc, rc)
+        self.assertEqual(exc.error, TPM2_RC.EXPIRED)
+        self.assertEqual(exc.handle, 0)
+        self.assertEqual(exc.parameter, 0)
+        self.assertEqual(exc.session, 1)

--- a/tpm2_pytss/TSS2_Exception.py
+++ b/tpm2_pytss/TSS2_Exception.py
@@ -1,2 +1,25 @@
+from .types import TPM2_RC
+
+
 class TSS2_Exception(RuntimeError):
-    pass
+    def __init__(self, rc):
+        super(TSS2_Exception, self).__init__(f"TSS2 Library call failed with: 0x{rc:X}")
+        self.rc = rc
+        self.handle = 0
+        self.parameter = 0
+        self.session = 0
+        self.error = 0
+        if self.rc & TPM2_RC.FMT1:
+            self._parse_fmt1()
+        else:
+            self.error = self.rc
+
+    def _parse_fmt1(self):
+        self.error = TPM2_RC.FMT1 + (self.rc & 0x3F)
+
+        if self.rc & TPM2_RC.P:
+            self.parameter = (self.rc & TPM2_RC.N_MASK) >> 8
+        elif self.rc & TPM2_RC.S:
+            self.session = ((self.rc - TPM2_RC.S) & TPM2_RC.N_MASK) >> 8
+        else:
+            self.handle = (self.rc & TPM2_RC.N_MASK) >> 8

--- a/tpm2_pytss/utils.py
+++ b/tpm2_pytss/utils.py
@@ -8,7 +8,7 @@ from .TSS2_Exception import TSS2_Exception
 
 def _chkrc(rc):
     if rc != 0:
-        raise TSS2_Exception(f"TSS2 Library call failed with: 0x{rc:X}")
+        raise TSS2_Exception(rc)
 
 
 def to_bytes_or_null(value, allow_null=True, encoding=None):


### PR DESCRIPTION
This is a more or less a cut and paste from the previous bindings.
Useful when debugging and could be used to provide better feedback/error messages from applications to users.