### PR TITLE
TSS2_Exception: plumb to tss2-rc

### DIFF
--- a/scripts/libtss2_build.py
+++ b/scripts/libtss2_build.py
@@ -24,7 +24,7 @@ def get_include_paths(library_names):
     return header_dirs
 
 
-libraries = ["tss2-esys", "tss2-tctildr", "tss2-fapi"]
+libraries = ["tss2-esys", "tss2-tctildr", "tss2-fapi", "tss2-rc"]
 
 # Set up the search path so we find prepare_header and other modules
 PATH = os.path.dirname(__file__) if len(os.path.dirname(__file__)) > 0 else os.getcwd()

--- a/scripts/prepare_headers.py
+++ b/scripts/prepare_headers.py
@@ -114,6 +114,13 @@ def prepare_fapi(dirpath):
     return remove_common_guards(s)
 
 
+def prepare_rcdecode(dirpath):
+
+    s = pathlib.Path(dirpath, "tss2_rc.h").read_text(encoding="utf-8")
+
+    return remove_common_guards(s)
+
+
 def prepare(indir, outfile):
     indir = os.path.join(indir, "tss2")
 
@@ -130,6 +137,8 @@ def prepare(indir, outfile):
     esapi = prepare_esapi(indir)
 
     fapi = prepare_fapi(indir)
+
+    rcdecode = prepare_rcdecode(indir)
 
     # Write result
     with open(outfile, "w") as f:
@@ -151,6 +160,7 @@ def prepare(indir, outfile):
         f.write(sapi)
         f.write(esapi)
         f.write(fapi)
+        f.write(rcdecode)
 
 
 if __name__ == "__main__":

--- a/tpm2_pytss/TSS2_Exception.py
+++ b/tpm2_pytss/TSS2_Exception.py
@@ -1,9 +1,12 @@
+from ._libtpm2_pytss import lib, ffi
 from .types import TPM2_RC
 
 
 class TSS2_Exception(RuntimeError):
     def __init__(self, rc):
-        super(TSS2_Exception, self).__init__(f"TSS2 Library call failed with: 0x{rc:X}")
+        errmsg = ffi.string(lib.Tss2_RC_Decode(rc)).decode()
+        super(TSS2_Exception, self).__init__(f"{errmsg}")
+
         self.rc = rc
         self.handle = 0
         self.parameter = 0


### PR DESCRIPTION
Use Tss2_RC_Decode to get the string representation of the error and
display it, plus fall back to 0x<RC> if for some reason the call fails.

Also drop the Long string, since the exception stacks and traces are
descriptive enough. It makes it too long.

Was:
tpm2_pytss.TSS2_Exception.TSS2_Exception: TSS2 Library call failed with: 0x70018

Is now:
tpm2_pytss.TSS2_Exception.TSS2_Exception: esapi:The ESYS_TR resource object is bad

Signed-off-by: William Roberts <william.c.roberts@intel.com>