### PR TITLE
test: mark FAPI tests as @pytest.mark.forked

### DIFF
--- a/test/test_fapi.py
+++ b/test/test_fapi.py
@@ -3,12 +3,13 @@
 SPDX-License-Identifier: BSD-3
 """
 
-import unittest
+import pytest
 
 from tpm2_pytss import *
 from .TSS2_BaseTest import TSS2_FapiTest
 
 
+@pytest.mark.forked
 class TestFapi(TSS2_FapiTest):
     def testProvision(self):
         r = self.fapi.provision()


### PR DESCRIPTION
Each FAPI test needs to be run in its own subprocess because it [exports the `TSS2_FAPICONF`](https://github.com/tpm2-software/tpm2-pytss/blob/e32432f691eb26aaa31603c0d29427a36fdcbc8f/tpm2_pytss/FAPI.py#L78) (a.k.a. [`FAPI_CONFIG_ENV`](https://github.com/tpm2-software/tpm2-pytss/blob/e32432f691eb26aaa31603c0d29427a36fdcbc8f/tpm2_pytss/FAPI.py#L15)) environment variable to point to its own temporary FAPI configuration. Not isolating the tests in different subprocesses leads to errors like
```
        if self.config is None:
            # Load the currently active fapi-config.json
            config_path = os.environ.get(FAPI_CONFIG_ENV, FAPI_CONFIG_PATH)
>           with open(config_path) as file:
E           FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmp3e2_8a4c'
```
because the next test tries to set up the configuration from the environment variable, which points to the old and possibly already deleted temporary configuration. This can be observed in the [latest master CI build](https://github.com/tpm2-software/tpm2-pytss/runs/2097176581#step:6:439).

Mark the FAPI tests as `@pytest.mark.forked` from the pytest-forked/pytest-xdist plugin (which we [already require as a development dependency](https://github.com/tpm2-software/tpm2-pytss/blob/e32432f691eb26aaa31603c0d29427a36fdcbc8f/setup.cfg#L40)) to force them to be run in individual subprocesses regardless of how the user calls pytest.