### PR TITLE
script/libtss2_build.py: add tss2-rc header file

### DIFF
--- a/scripts/libtss2_build.py
+++ b/scripts/libtss2_build.py
@@ -59,6 +59,7 @@ ffibuilder.set_source(
      #include <tss2/tss2_esys.h>
      #include <tss2/tss2_tctildr.h>
      #include <tss2/tss2_fapi.h>
+     #include <tss2/tss2_rc.h>
 """,
     libraries=libraries,
 )  # library name, for the linker


### PR DESCRIPTION
The header file was missing, leading to compilation warnings like
```
build/temp.linux-x86_64-3.6/tpm2_pytss._libtpm2_pytss.c:38178:10: warning: implicit declaration of function 'Tss2_RC_Decode'; did you mean 'Tss2_Sys_Quote'? [-Wimplicit-function-declaration]
```
and `test_exception.py` crashing with a segmentation fault on my system.