### PR TITLE
types.py: support setting struct/union fields during initialization

### DIFF
--- a/test/test_types.py
+++ b/test/test_types.py
@@ -273,6 +273,12 @@ class ExceptionTest(unittest.TestCase):
         ):
             TPM2B_DIGEST(badfield=1)
 
+    def test_TPM_OBJECT_init_cdata(self):
+        with self.assertRaises(
+            TypeError, msg="Unexpected _cdata type uint8_t, expected TPM2B_DIGEST"
+        ):
+            TPM2B_DIGEST(_cdata=ffi.new("uint8_t *"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -261,6 +261,18 @@ class ExceptionTest(unittest.TestCase):
             inPublic.publicArea.parameters.eccDetail.curveID, TPM2_ECC.NIST_P256
         )
 
+    def test_TPM_OBJECT_init(self):
+        digest = TPM2B_DIGEST(size=4, buffer=b"test")
+
+        self.assertEqual(digest.size, 4)
+        b = ffi.buffer(digest.buffer, digest.size)
+        self.assertEqual(b, b"test")
+
+        with self.assertRaises(
+            AttributeError, msg="TPM2B_DIGEST has no field by the name of badfield"
+        ):
+            TPM2B_DIGEST(badfield=1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -744,12 +744,23 @@ class TPMA_MEMORY(int):
 
 
 class TPM_OBJECT(object):
-    def __init__(self, _cdata=None):
+    def __init__(self, _cdata=None, **kwargs):
 
         if _cdata is None:
             _cdata = ffi.new(f"{self.__class__.__name__} *")
 
         self._cdata = _cdata
+
+        tipe = ffi.typeof(_cdata)
+        if tipe.kind == "pointer":
+            tipe = tipe.item
+        fields = [x[0] for x in tipe.fields]
+        for k, v in kwargs.items():
+            if k not in fields:
+                raise AttributeError(
+                    f"{self.__class__.__name__} has no field by the name of {k}"
+                )
+            self.__setattr__(k, v)
 
     @staticmethod
     def _fixup_classname(tipe):

--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -754,6 +754,10 @@ class TPM_OBJECT(object):
         tipe = ffi.typeof(_cdata)
         if tipe.kind == "pointer":
             tipe = tipe.item
+        if tipe.cname != self.__class__.__name__:
+            raise TypeError(
+                f"Unexpected _cdata type {tipe.cname}, expected {self.__class__.__name__}"
+            )
         fields = [x[0] for x in tipe.fields]
         for k, v in kwargs.items():
             if k not in fields:


### PR DESCRIPTION
This enables things like TPMS_NV_PUBLIC(nameAlg=TPM2_ALG.SHA256)