### PR TITLE
Dockerfile: drop COPY of local workspace

### DIFF
--- a/.ci/Dockerfile.tpm2-tss-python
+++ b/.ci/Dockerfile.tpm2-tss-python
@@ -16,4 +16,3 @@ RUN bash -c 'source /workspace/tpm2-pytss/.ci/download-deps.sh && get_deps /work
 ENV TSS2_LOG=all+trace
 
 WORKDIR /workspace/tpm2-pytss
-COPY . /workspace/tpm2-pytss

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
 
 [options.extras_require]
 dev =
+    docutils==0.16
     coverage
     codecov
     sphinx


### PR DESCRIPTION
We mount the git repo through using -v in docker commands, no need to
explicitly copy the contents into the Docker Image.

Signed-off-by: William Roberts <william.c.roberts@intel.com>