### PR TITLE
types: make TPML_* init smarter

### DIFF
--- a/test/test_types.py
+++ b/test/test_types.py
@@ -101,7 +101,7 @@ class TypesTest(unittest.TestCase):
         second = TPMS_PCR_SELECTION.parse("sha384:all")
         third = TPMS_PCR_SELECTION.parse("sha1:1,3")
 
-        pcr_sels = TPML_PCR_SELECTION([first, second, third])
+        pcr_sels = TPML_PCR_SELECTION(pcrSelections=[first, second, third])
         self.assertEqual(pcr_sels.count, 3)
 
         x = pcr_sels.pcrSelections[0]


### PR DESCRIPTION
Rather than needing to write code to handle every TPML initialization,
since thier is only count and one other field, make it smarter and have
it figure out how to initialize objets in one of three conditions:
  - _cdata is specified
  - kwargs is specified using the field value to set
  - they just passed data into the constructor:
      _cdata is set but NOT with CFFI CData.

Signed-off-by: William Roberts <william.c.roberts@intel.com>