### PR TITLE
more tests and type enhancements

### DIFF
--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -194,6 +194,43 @@ class TestEsys(TSS2_EsapiTest):
         random = self.ectx.GetRandom(4, session1=session)
         self.assertEqual(len(random), 4)
 
+    def test_start_authSession_enckey_bindkey(self):
+
+        alg = "rsa2048:aes128cfb"
+        attrs = TPMA_OBJECT.DEFAULT_TPM2_TOOLS_CREATEPRIMARY_ATTRS
+        inPublic = TPM2B_PUBLIC(TPMT_PUBLIC.parse(alg=alg, objectAttributes=attrs))
+        inSensitive = TPM2B_SENSITIVE_CREATE(
+            TPMS_SENSITIVE_CREATE(userAuth=TPM2B_AUTH("password"))
+        )
+        outsideInfo = TPM2B_DATA()
+        creationPCR = TPML_PCR_SELECTION()
+
+        handle, _, _, _, _ = self.ectx.CreatePrimary(
+            ESYS_TR.OWNER, inSensitive, inPublic, outsideInfo, creationPCR
+        )
+
+        sym = TPMT_SYM_DEF(
+            algorithm=TPM2_ALG.XOR,
+            keyBits=TPMU_SYM_KEY_BITS(exclusiveOr=TPM2_ALG.SHA256),
+            mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
+        )
+
+        session = self.ectx.StartAuthSession(
+            tpmKey=handle,
+            bind=handle,
+            nonceCaller=None,
+            sessionType=TPM2_SE.POLICY,
+            symmetric=sym,
+            authHash=TPM2_ALG.SHA256,
+        )
+
+        self.ectx.TRSess_SetAttributes(
+            session, (TPMA_SESSION.ENCRYPT | TPMA_SESSION.DECRYPT)
+        )
+
+        random = self.ectx.GetRandom(4, session1=session)
+        self.assertEqual(len(random), 4)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -121,6 +121,17 @@ class TestEsys(TSS2_EsapiTest):
 
         self.ectx.IncrementalSelfTest(algs)
 
+    def test_incremental_resume_test(self):
+        algs = TPML_ALG.parse("rsa,ecc,xor,aes,cbc")
+
+        self.ectx.IncrementalSelfTest(algs)
+        toDo, rc = self.ectx.GetTestResult()
+        self.assertTrue(
+            isinstance(toDo, TPM2B_MAX_BUFFER),
+            f"Expected TODO list to be TPM2B_MAX_BUFFER, got: {type(toDo)}",
+        )
+        self.assertEqual(rc, TPM2_RC.SUCCESS)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -265,7 +265,7 @@ class TypesTest(unittest.TestCase):
         digest = TPM2B_DIGEST(size=4, buffer=b"test")
 
         self.assertEqual(digest.size, 4)
-        b = ffi.buffer(digest.buffer, digest.size)
+        b = digest.buffer
         self.assertEqual(b, b"test")
 
         with self.assertRaises(
@@ -583,7 +583,7 @@ class TypesTest(unittest.TestCase):
         d, offset = TPM2B_DIGEST.Unmarshal(buf)
         self.assertEqual(offset, 7)
         self.assertEqual(d.size, 5)
-        db = ffi.buffer(d.buffer, d.size)
+        db = d.buffer
         self.assertEqual(db, b"test1")
 
     def test_TPMT_PUBLIC_empty(self):
@@ -979,6 +979,25 @@ class TypesTest(unittest.TestCase):
         self.assertEqual(t[2].hash, TPM2_ALG.SHA512)
         self.assertEqual(t[2].pcrSelect[0], 128)
         self.assertEqual(len(t), 3)
+
+    def test_TPM2B_AUTH_empty(self):
+        x = TPM2B_AUTH()
+        self.assertEqual(x.size, 0)
+
+    def test_TPM2B_AUTH_bad_fields(self):
+        with self.assertRaises(AttributeError):
+            TPM2B_AUTH(foo="bar")
+
+    def test_TPM2B_AUTH_empty_str(self):
+        x = TPM2B_AUTH("")
+        self.assertEqual(x.size, 0)
+
+    def test_TPM2B_AUTH_set_str(self):
+        # You can send it in as a string
+        x = TPM2B_AUTH("password")
+        self.assertEqual(x.size, 8)
+        # but you get bytes back
+        self.assertEqual(x.buffer, b"password")
 
 
 if __name__ == "__main__":

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -2,6 +2,7 @@
 """
 SPDX-License-Identifier: BSD-3
 """
+import binascii
 import itertools
 import unittest
 
@@ -998,6 +999,13 @@ class TypesTest(unittest.TestCase):
         self.assertEqual(x.size, 8)
         # but you get bytes back
         self.assertEqual(x.buffer, b"password")
+        self.assertEqual(bytes(x), b"password")
+
+    def test_TPMS_SENSITIVE_CREATE_with_string(self):
+
+        x = TPMS_SENSITIVE_CREATE(userAuth="password")
+        p = str(x.userAuth)
+        self.assertEqual(p, binascii.hexlify("password".encode()).decode())
 
 
 if __name__ == "__main__":

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -98,6 +98,9 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
+        if nonceCaller is None:
+            nonceCaller = ffi.NULL
+
         sessionHandle = ffi.new("ESYS_TR *")
         _chkrc(
             lib.Esys_StartAuthSession(
@@ -109,7 +112,7 @@ class ESAPI:
                 session3,
                 nonceCaller,
                 sessionType,
-                symmetric,
+                symmetric._cdata,
                 authHash,
                 sessionHandle,
             )

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -1702,7 +1702,7 @@ class ESAPI:
         inPublic,
         outsideInfo,
         creationPCR,
-        session1=ESYS_TR.NONE,
+        session1=ESYS_TR.PASSWORD,
         session2=ESYS_TR.NONE,
         session3=ESYS_TR.NONE,
     ):

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -120,6 +120,10 @@ class ESAPI:
         sessionHandleObject = sessionHandle[0]
         return sessionHandleObject
 
+    def TRSess_SetAttributes(self, session, attributes, mask=0xFF):
+
+        _chkrc(lib.Esys_TRSess_SetAttributes(self.ctx, session, attributes, mask))
+
     def PolicyRestart(
         self,
         sessionHandle,

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -83,7 +83,7 @@ class ESAPI:
                 self.ctx, session1, session2, session3, outData, testResult
             )
         )
-        return (outData[0], testResult[0])
+        return (TPM2B_MAX_BUFFER(outData[0]), TPM2_RC(testResult[0]))
 
     def StartAuthSession(
         self,

--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -873,7 +873,6 @@ class TPM_OBJECT(object):
             return obj
 
     def __setattr__(self, key, value):
-        # print(f"SET ATTRIBUTE {key}")
         try:
             # Get _cdata without invoking getattr
             _cdata = object.__getattribute__(self, "_cdata")

--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -1870,3 +1870,6 @@ class TPMU_SYM_MODE(TPM_OBJECT):
 
 class TPMT_SYM_DEF(TPM_OBJECT):
     pass
+
+class TPM2B_AUTH(TPM2B_OBJECT):
+    pass

--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -887,7 +887,7 @@ class TPM_OBJECT(object):
             ):
                 value = value.encode()
             setattr(_cdata, key, value)
-        except (AttributeError, TypeError):
+        except AttributeError:
             return object.__setattr__(self, key, value)
 
     def Marshal(self):

--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -1894,3 +1894,7 @@ class TPMU_SYM_KEY_BITS(TPM_OBJECT):
 
 class TPMU_SYM_MODE(TPM_OBJECT):
     pass
+
+
+class TPMT_SYM_DEF(TPM_OBJECT):
+    pass

--- a/tpm2_pytss/utils.py
+++ b/tpm2_pytss/utils.py
@@ -84,12 +84,11 @@ def fixup_cdata_kwargs(this, _cdata, kwargs):
 
     # folks may call this routine without a keyword argument which means it may
     # end up in _cdata, so we want to try and work this out
-    null_cdata = _cdata == None
     unknown = None
     try:
         # is _cdata actual ffi data?
         ffi.typeof(_cdata)
-    except TypeError:
+    except (TypeError, ffi.error):
         # No, its some type of pyton data, so clear it from _cdata and call init
         unknown = _cdata
         _cdata = None
@@ -114,7 +113,5 @@ def fixup_cdata_kwargs(this, _cdata, kwargs):
         kwargs[field_name] = unknown
     elif len(kwargs) == 0:
         return (_cdata, {})
-    elif not null_cdata and len(kwargs) != 1:
-        raise RuntimeError(f"Expected at most one key value pair, got: {len(kwargs)}")
 
     return (_cdata, kwargs)


### PR DESCRIPTION
William Roberts (13):
      ESAPI: test IncrementalSelfTest
      ESAPI: test StartAuthsession for HMAC
      TPM2_OBJECT: support simpler initializations
      ESAPI: set session1 ESYS_TR.PASSWORD
      ESAPI: add TRSess_SetAttributes
      ESAPI: test StartAuthSession with tpmKey
      Catch when type is string, ffi.error is returned
      TPM2B_ make types even smarter
      types: make TPML_ types smarter
      ESAPI: support StartAuthSession with tpmKey and bindKey
      types: don't hide typerror
      types: drop commented out code
      types: TPM2B_ add bytes and str methods for all TPM2B types
