### PR TITLE
ESAPI Tests (StartAuthSession, Create, Load, Readpublic) and Implement Test TPML iteration

### DIFF
--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -268,6 +268,41 @@ class TestEsys(TSS2_EsapiTest):
         random = self.ectx.GetRandom(4, session1=session)
         self.assertEqual(len(random), 4)
 
+    def test_create(self):
+
+        alg = "rsa2048:aes128cfb"
+        attrs = TPMA_OBJECT.DEFAULT_TPM2_TOOLS_CREATEPRIMARY_ATTRS
+        inPublic = TPM2B_PUBLIC(TPMT_PUBLIC.parse(alg=alg, objectAttributes=attrs))
+        inSensitive = TPM2B_SENSITIVE_CREATE(
+            TPMS_SENSITIVE_CREATE(userAuth=TPM2B_AUTH("password"))
+        )
+        outsideInfo = TPM2B_DATA()
+        creationPCR = TPML_PCR_SELECTION()
+
+        parentHandle, _, _, _, _ = self.ectx.CreatePrimary(
+            ESYS_TR.OWNER, inSensitive, inPublic, outsideInfo, creationPCR
+        )
+
+        childInSensitive = TPM2B_SENSITIVE_CREATE(
+            TPMS_SENSITIVE_CREATE(userAuth=TPM2B_AUTH("childpassword"))
+        )
+
+        alg = "rsa2048"
+        attrs = TPMA_OBJECT.DEFAULT_TPM2_TOOLS_CREATE_ATTRS
+        childInPublic = TPM2B_PUBLIC(TPMT_PUBLIC.parse(alg=alg, objectAttributes=attrs))
+
+        priv, pub, _, _, _ = self.ectx.Create(
+            parentHandle, childInSensitive, childInPublic, outsideInfo, creationPCR
+        )
+
+        self.assertTrue(
+            isinstance(priv, TPM2B_PRIVATE),
+            f"Expected TPM2B_PRIVATE, got: {type(priv)}",
+        )
+        self.assertTrue(
+            isinstance(pub, TPM2B_PUBLIC), f"Expected TPM2B_PUBLIC, got: {type(pub)}"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -333,6 +333,52 @@ class TestEsys(TSS2_EsapiTest):
         childHandle = self.ectx.Load(parentHandle, priv, pub)
         self.assertTrue(childHandle)
 
+    def test_readpublic(self):
+
+        alg = "rsa2048:aes128cfb"
+        attrs = TPMA_OBJECT.DEFAULT_TPM2_TOOLS_CREATEPRIMARY_ATTRS
+        inPublic = TPM2B_PUBLIC(TPMT_PUBLIC.parse(alg=alg, objectAttributes=attrs))
+        inSensitive = TPM2B_SENSITIVE_CREATE(
+            TPMS_SENSITIVE_CREATE(userAuth=TPM2B_AUTH("password"))
+        )
+        outsideInfo = TPM2B_DATA()
+        creationPCR = TPML_PCR_SELECTION()
+
+        parentHandle, _, _, _, _ = self.ectx.CreatePrimary(
+            ESYS_TR.OWNER, inSensitive, inPublic, outsideInfo, creationPCR
+        )
+
+        childInSensitive = TPM2B_SENSITIVE_CREATE(
+            TPMS_SENSITIVE_CREATE(userAuth=TPM2B_AUTH("childpassword"))
+        )
+
+        alg = "rsa2048"
+        attrs = TPMA_OBJECT.DEFAULT_TPM2_TOOLS_CREATE_ATTRS
+        childInPublic = TPM2B_PUBLIC(TPMT_PUBLIC.parse(alg=alg, objectAttributes=attrs))
+
+        priv, pub, _, _, _ = self.ectx.Create(
+            parentHandle, childInSensitive, childInPublic, outsideInfo, creationPCR
+        )
+
+        childHandle = self.ectx.Load(parentHandle, priv, pub)
+
+        pubdata, name, qname = self.ectx.ReadPublic(childHandle)
+        self.assertTrue(
+            isinstance(pubdata, TPM2B_PUBLIC),
+            f"Expected TPM2B_PUBLIC, got: {type(pubdata)}",
+        )
+        self.assertTrue(
+            isinstance(name, TPM2B_NAME), f"Expected TPM2B_NAME, got: {type(name)}"
+        )
+        self.assertTrue(
+            isinstance(qname, TPM2B_NAME), f"Expected TPM2B_NAME, got: {type(qname)}"
+        )
+
+        self.assertTrue(pubdata.publicArea.type, TPM2_ALG.RSA)
+        self.assertTrue(pubdata.publicArea.nameAlg, TPM2_ALG.SHA256)
+        self.assertTrue(name.size, 32)
+        self.assertTrue(qname.size, 32)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -231,6 +231,43 @@ class TestEsys(TSS2_EsapiTest):
         random = self.ectx.GetRandom(4, session1=session)
         self.assertEqual(len(random), 4)
 
+    def test_start_authSession_noncecaller(self):
+
+        alg = "rsa2048:aes128cfb"
+        attrs = TPMA_OBJECT.DEFAULT_TPM2_TOOLS_CREATEPRIMARY_ATTRS
+        inPublic = TPM2B_PUBLIC(TPMT_PUBLIC.parse(alg=alg, objectAttributes=attrs))
+        inSensitive = TPM2B_SENSITIVE_CREATE(
+            TPMS_SENSITIVE_CREATE(userAuth=TPM2B_AUTH("password"))
+        )
+        outsideInfo = TPM2B_DATA()
+        creationPCR = TPML_PCR_SELECTION()
+
+        handle, _, _, _, _ = self.ectx.CreatePrimary(
+            ESYS_TR.OWNER, inSensitive, inPublic, outsideInfo, creationPCR
+        )
+
+        sym = TPMT_SYM_DEF(
+            algorithm=TPM2_ALG.XOR,
+            keyBits=TPMU_SYM_KEY_BITS(exclusiveOr=TPM2_ALG.SHA256),
+            mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
+        )
+
+        session = self.ectx.StartAuthSession(
+            tpmKey=handle,
+            bind=handle,
+            nonceCaller=TPM2B_NONCE(b"thisisthirtytwocharslastichecked"),
+            sessionType=TPM2_SE.POLICY,
+            symmetric=sym,
+            authHash=TPM2_ALG.SHA256,
+        )
+
+        self.ectx.TRSess_SetAttributes(
+            session, (TPMA_SESSION.ENCRYPT | TPMA_SESSION.DECRYPT)
+        )
+
+        random = self.ectx.GetRandom(4, session1=session)
+        self.assertEqual(len(random), 4)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -981,6 +981,36 @@ class TypesTest(unittest.TestCase):
         self.assertEqual(t[2].pcrSelect[0], 128)
         self.assertEqual(len(t), 3)
 
+    def test_TPML_PCR_SELECTION_iterator(self):
+        pcrselections = TPML_PCR_SELECTION.parse("sha256:1,2,3+sha384:0,5,6+sha512:7")
+
+        self.assertEqual(len(pcrselections), 3)
+
+        for i, selection in enumerate(pcrselections):
+
+            if i == 0:
+                self.assertEqual(selection.hash, TPM2_ALG.SHA256)
+                self.assertEqual(selection.pcrSelect[0], 14)
+            elif i == 1:
+                self.assertEqual(selection.hash, TPM2_ALG.SHA384)
+                self.assertEqual(selection.pcrSelect[0], 97)
+            elif i == 2:
+                self.assertEqual(selection.hash, TPM2_ALG.SHA512)
+                self.assertEqual(selection.pcrSelect[0], 128)
+
+        # make sure state resets
+        for i, selection in enumerate(pcrselections):
+
+            if i == 0:
+                self.assertEqual(selection.hash, TPM2_ALG.SHA256)
+                self.assertEqual(selection.pcrSelect[0], 14)
+            elif i == 1:
+                self.assertEqual(selection.hash, TPM2_ALG.SHA384)
+                self.assertEqual(selection.pcrSelect[0], 97)
+            elif i == 2:
+                self.assertEqual(selection.hash, TPM2_ALG.SHA512)
+                self.assertEqual(selection.pcrSelect[0], 128)
+
     def test_TPM2B_AUTH_empty(self):
         x = TPM2B_AUTH()
         self.assertEqual(x.size, 0)

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -190,7 +190,7 @@ class ESAPI:
         parentHandle,
         inPrivate,
         inPublic,
-        session1=ESYS_TR.NONE,
+        session1=ESYS_TR.PASSWORD,
         session2=ESYS_TR.NONE,
         session3=ESYS_TR.NONE,
     ):
@@ -203,12 +203,12 @@ class ESAPI:
                 session1,
                 session2,
                 session3,
-                inPrivate,
-                inPublic,
+                inPrivate._cdata,
+                inPublic._cdata,
                 objectHandle,
             )
         )
-        objectHandleObject = objectHandle
+        objectHandleObject = objectHandle[0]
         return objectHandleObject
 
     def LoadExternal(

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -100,6 +100,10 @@ class ESAPI:
 
         if nonceCaller is None:
             nonceCaller = ffi.NULL
+        elif isinstance(nonceCaller, TPM_OBJECT):
+            nonceCaller = nonceCaller._cdata
+        else:
+            raise TypeError("Expected nonceCaller to be None or TPM_OBJECT")
 
         sessionHandle = ffi.new("ESYS_TR *")
         _chkrc(

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -260,7 +260,11 @@ class ESAPI:
                 qualifiedName,
             )
         )
-        return (outPublic[0], name[0], qualifiedName[0])
+        return (
+            TPM2B_PUBLIC(outPublic[0]),
+            TPM2B_NAME(name[0]),
+            TPM2B_NAME(qualifiedName[0]),
+        )
 
     def ActivateCredential(
         self,

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -149,7 +149,7 @@ class ESAPI:
         inPublic,
         outsideInfo,
         creationPCR,
-        session1=ESYS_TR.NONE,
+        session1=ESYS_TR.PASSWORD,
         session2=ESYS_TR.NONE,
         session3=ESYS_TR.NONE,
     ):
@@ -166,10 +166,10 @@ class ESAPI:
                 session1,
                 session2,
                 session3,
-                inSensitive,
-                inPublic,
-                outsideInfo,
-                creationPCR,
+                inSensitive._cdata,
+                inPublic._cdata,
+                outsideInfo._cdata,
+                creationPCR._cdata,
                 outPrivate,
                 outPublic,
                 creationData,
@@ -178,11 +178,11 @@ class ESAPI:
             )
         )
         return (
-            outPrivate[0],
-            outPublic[0],
-            creationData[0],
-            creationHash[0],
-            creationTicket[0],
+            TPM2B_PRIVATE(outPrivate[0]),
+            TPM2B_PUBLIC(outPublic[0]),
+            TPM2B_CREATION_DATA(creationData[0]),
+            TPM2B_DIGEST(creationHash[0]),
+            TPMT_TK_CREATION(creationTicket[0]),
         )
 
     def Load(

--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -1905,3 +1905,7 @@ class TPMT_SYM_DEF(TPM_OBJECT):
 
 class TPM2B_AUTH(TPM2B_OBJECT):
     pass
+
+
+class TPM2B_NONCE(TPM2B_OBJECT):
+    pass

--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -1141,10 +1141,6 @@ class TPML_OBJECT(TPM_OBJECT):
     def __iter__(self):
         return TPML_Iterator(self)
 
-    @staticmethod
-    def _getitem_unpacker(x):
-        return x
-
 
 class TPMU_PUBLIC_PARMS(TPM_OBJECT):
     pass

--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -971,6 +971,24 @@ class TPM2B_OBJECT(TPM_OBJECT):
         return h.decode()
 
 
+class TPML_Iterator(object):
+    def __init__(self, tpml):
+        self._tpml = tpml
+        self._index = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+
+        if self._index > self._tpml.count - 1:
+            raise StopIteration
+
+        x = self._tpml[self._index]
+        self._index = self._index + 1
+        return x
+
+
 class TPML_OBJECT(TPM_OBJECT):
     def __init__(self, _cdata=None, **kwargs):
 
@@ -1119,6 +1137,9 @@ class TPML_OBJECT(TPM_OBJECT):
 
         if key.stop > self._cdata.count:
             self._cdata.count = key.stop
+
+    def __iter__(self):
+        return TPML_Iterator(self)
 
     @staticmethod
     def _getitem_unpacker(x):


### PR DESCRIPTION
William Roberts (6):
      ESAPI: test StartAuthSession w/nonceCaller
      ESAPI: test Create
      ESAPI: test load
      ESAPI: test ReadPublic
      TPML_OBJECT: make iterable
      types: get rid of all remnants of unpacker