### PR TITLE
types.py: add TPM2B_OBJECT to handle size + buffer structures

### DIFF
--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -6,7 +6,7 @@ from ._libtpm2_pytss import lib
 
 from .types import *
 
-from .utils import _chkrc, TPM2B_pack
+from .utils import _chkrc, TPM2B_pack, TPM2B_unpack
 
 
 class ESAPI:

--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -6,7 +6,6 @@ from ._libtpm2_pytss import ffi, lib
 
 from tpm2_pytss.utils import (
     CLASS_INT_ATTRS_from_string,
-    TPM2B_unpack,
     _chkrc,
     fixup_cdata_kwargs,
     cpointer_to_ctype,


### PR DESCRIPTION
* Makes the size attribute read only
* Keeps track of buffer size when buffer is changed
* Makes buffer data inmutable
* Makes the class indexable, iterable and sliceable

I had to change unrelated tests as they where using TPM2B_DIGEST