### PR TITLE
Support setting byte buffers in TPM2B if supported

### DIFF
--- a/test/test_types.py
+++ b/test/test_types.py
@@ -1048,6 +1048,10 @@ class TypesTest(unittest.TestCase):
         self.assertEqual(len(n), x.size)
         self.assertEqual(n, name)
 
+    def test_TPM2B_PUBLIC_fail_from_bytes(self):
+        with self.assertRaises(TypeError):
+            TPM2B_PUBLIC(b"0011223344556677889900")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -1037,6 +1037,17 @@ class TypesTest(unittest.TestCase):
         p = str(x.userAuth)
         self.assertEqual(p, binascii.hexlify("password".encode()).decode())
 
+    def test_TPM2B_NAME(self):
+        name = binascii.unhexlify(
+            "000b34e9133541f7874f5ec2cd867b873b05cea0c1677b0cc7d740988e999bee5450"
+        )
+        print(len(name))
+        x = TPM2B_NAME(name)
+        self.assertEqual(x.size, 34)
+        n = bytes(x)
+        self.assertEqual(len(n), x.size)
+        self.assertEqual(n, name)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
For TPM2B types where the sub field is only a buffer, allow constructors to instantiate it from bytes. This will be for things like TPM2B_DIGEST and TPM2B_NAME structures. This will also fail on compound structures like TPM2B_PUBLIC.

@ Whoo what about this over parts of 90? You can make size RO ontop of this PR?

