### PR TITLE
LGTM: fix constructor calling subclass method

### DIFF
--- a/test/test_types.py
+++ b/test/test_types.py
@@ -1065,6 +1065,30 @@ class TypesTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             dig.name[0] = b"\x00"
 
+    def test_TPMS_ECC_POINT(self):
+
+        x = b"12345678"
+        y = b"87654321"
+        t = TPMS_ECC_POINT(x=x, y=y)
+        self.assertEqual(bytes(t.x), x)
+        self.assertEqual(bytes(t.y), y)
+        self.assertEqual(len(t.x), len(x))
+        self.assertEqual(len(t.y), len(y))
+
+        self.assertEqual(str(t.x), binascii.hexlify(x).decode())
+        self.assertEqual(str(t.y), binascii.hexlify(y).decode())
+
+        x = "thisisareallylongstringx"
+        y = "thisisareallylongstringy"
+        t = TPMS_ECC_POINT(x=x, y=y)
+        self.assertEqual(bytes(t.x), x.encode())
+        self.assertEqual(bytes(t.y), y.encode())
+        self.assertEqual(len(t.x), len(x.encode()))
+        self.assertEqual(len(t.y), len(y.encode()))
+
+        self.assertEqual(str(t.x), binascii.hexlify(x.encode()).decode())
+        self.assertEqual(str(t.y), binascii.hexlify(y.encode()).decode())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -1089,6 +1089,19 @@ class TypesTest(unittest.TestCase):
         self.assertEqual(str(t.x), binascii.hexlify(x.encode()).decode())
         self.assertEqual(str(t.y), binascii.hexlify(y.encode()).decode())
 
+        x = b"12345678"
+        y = b"87654321"
+        t = TPMS_ECC_POINT()
+        t.x = x
+        t.y = y
+        self.assertEqual(bytes(t.x), x)
+        self.assertEqual(bytes(t.y), y)
+        self.assertEqual(len(t.x), len(x))
+        self.assertEqual(len(t.y), len(y))
+
+        self.assertEqual(str(t.x), binascii.hexlify(x).decode())
+        self.assertEqual(str(t.y), binascii.hexlify(y).decode())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
LGTM issued the following warning:
`NEWCall to self.__setattr__ in __init__ method, which is overridden by method TPM2B_SIMPLE_OBJECT.__setattr__.`

The help document for the issue is:
https://lgtm.com/rules/10030085/

LGTM's help document was clear that we should avoid this paradigm. In
this case it worked fine, but lets minimize warnings and bad patterns
when possible.

Signed-off-by: William Roberts <william.c.roberts@intel.com>