### PR TITLE
Drop codecov token

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -26,7 +26,7 @@ function run_test() {
     tpm2software/tpm2-tss-python \
     /bin/bash -c '/workspace/tpm2-pytss/.ci/docker.run'
 
-  if [ "x${CODECOV_TOKEN}" != "x" ]; then
+  if [ -n "${ENABLE_COVERAGE}" ]; then
     "${PYTHON}" -m codecov
   fi
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,11 +31,12 @@ jobs:
         python -m pip install --upgrade twine codecov black==19.10b0
         docker build -t tpm2software/tpm2-tss-python -f .ci/Dockerfile.tpm2-tss-python .
     - name: Test
+      env:
+        CODECOV_TOKEN: true
       run: |
         export PATH="${HOME}/.local/bin:${PATH}"
         export TWINE_USERNAME=__token__
         export TWINE_PASSWORD=${{ secrets.PYPI_TPM2_PYTSS }}
-        export CODECOV_TOKEN=${{ secrets.CODECOV_TOKEN }}
         export GITHUB_PAGES_KEY=${{ secrets.GITHUB_PAGES_KEY }}
         export ${{ matrix.check }}=1
         ./.ci/run.sh


### PR DESCRIPTION
- Drop codecov token from the secrets, its not needed.
- Cleanup exports into the env variable for Github Actions.
- Make the run.sh script use an argument over magic env variable.