### PR TITLE
more ci changes

### DIFF
--- a/.ci/Dockerfile.tpm2-tss-python
+++ b/.ci/Dockerfile.tpm2-tss-python
@@ -1,13 +1,6 @@
 FROM ghcr.io/tpm2-software/ubuntu-18.04
 
-RUN apt-get -y update && \
-  apt-get -y install \
-    python3 \
-    python3-dev \
-    python3-pip \
-    swig && \
-  rm -rf /var/lib/apt/lists/* && \
-  python3 -m pip install -U pip setuptools wheel virtualenv
+RUN python3 -m pip install -U pip setuptools wheel virtualenv
 
 COPY .ci/download-deps.sh /workspace/tpm2-pytss/.ci/download-deps.sh
 

--- a/.ci/Dockerfile.tpm2-tss-python-black
+++ b/.ci/Dockerfile.tpm2-tss-python-black
@@ -1,6 +1,0 @@
-FROM python:3.7
-
-RUN pip install -U pip && \
-  pip install -U black
-
-ENTRYPOINT black

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -8,6 +8,9 @@ fi
 SRC_ROOT=${SRC_ROOT:-"${PWD}"}
 PYTHON=${PYTHON:-"python3"}
 
+PUBLISH_AUTHOR_NAME="TPM2 CI Bot"
+PUBLISH_AUTHOR_EMAIL="tpm2-pytss-gh-pages@outlook.com"
+
 TEMP_DIRS=()
 
 function run_publish_pkg() {
@@ -129,8 +132,8 @@ function run_docs() {
 
   cd "${release_docs}/html"
 
-  git config user.name 'John Andersen'
-  git config user.email 'johnandersenpdx@gmail.com'
+  git config user.name "${PUBLISH_AUTHOR_NAME}"
+  git config user.email "${PUBLISH_AUTHOR_EMAIL}"
 
   git add -A
   git commit -sam "docs: $(date)"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -86,7 +86,7 @@ function run_build_docs() {
 }
 
 
-function run_docs() {
+function run_publish_docs() {
   export GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
 
   cd "${SRC_ROOT}"
@@ -192,4 +192,6 @@ elif [ "x${DOCS}" != "x" ]; then
   run_build_docs
 elif [ "x${PUBLISH_PKG}" != "x" ]; then
   run_publish_pkg
+elif [ "x${PUBLISH_DOCS}" != "x" ]; then
+  run_publish_docs
 fi

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -75,6 +75,17 @@ function run_style() {
   "${PYTHON}" -m black --check "${SRC_ROOT}"
 }
 
+function run_build_docs() {
+
+  docker run --rm \
+    -u $(id -u):$(id -g) \
+    -v "${PWD}:/workspace/tpm2-pytss" \
+    --env-file .ci/docker.env \
+    tpm2software/tpm2-tss-python \
+    /bin/bash -c 'virtualenv .venv && . .venv/bin/activate && . .ci/docker-prelude.sh && python3 -m pip install -e .[dev] && ./scripts/docs.sh '
+}
+
+
 function run_docs() {
   export GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
 
@@ -178,7 +189,7 @@ elif [ "x${WHITESPACE}" != "x" ]; then
 elif [ "x${STYLE}" != "x" ]; then
   run_style
 elif [ "x${DOCS}" != "x" ]; then
-  run_docs
+  run_build_docs
 elif [ "x${PUBLISH_PKG}" != "x" ]; then
   run_publish_pkg
 fi

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -1,0 +1,27 @@
+name: Publish Github Pages
+
+on: push
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+
+    - name: Install Dependencies
+      run: |
+        python3 -m pip install --user --upgrade pip
+        python3 -m pip install --user --upgrade twine
+        docker build -t tpm2software/tpm2-tss-python -f .ci/Dockerfile.tpm2-tss-python .
+
+    - name: Test
+      env:
+        TEST: 1
+      run: ./.ci/run.sh
+
+    - name: Publish to GH Pages
+      env:
+        PUBLISH_DOCS: 1
+        SSH_TPM2_PYTSS_GH_PAGES: ${{ secrets.SSH_TPM2_PYTSS_GH_PAGES }}
+      run: ./.ci/run.sh

--- a/.github/workflows/publish_pkg.yaml
+++ b/.github/workflows/publish_pkg.yaml
@@ -1,0 +1,31 @@
+name: Publish PyPI Package
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+
+    - name: Install Dependencies
+      run: |
+        python3 -m pip install --user --upgrade pip
+        python3 -m pip install --user --upgrade twine
+        docker build -t tpm2software/tpm2-tss-python -f .ci/Dockerfile.tpm2-tss-python .
+
+    - name: Test
+      env:
+        TEST: 1
+      run: ./.ci/run.sh
+
+    - name: Publish to PyPi
+      env:
+        PUBLISH_PKG: 1
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_TPM2_PYTSS }}
+      run: ./.ci/run.sh

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,11 +15,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install Dependencies
-      run: |
-        mkdir -p ~/.local/bin
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade twine
-        docker build -t tpm2software/tpm2-tss-python -f .ci/Dockerfile.tpm2-tss-python .
+      run: docker build -t tpm2software/tpm2-tss-python -f .ci/Dockerfile.tpm2-tss-python .
 
     - name: Test
       env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,14 +23,9 @@ jobs:
 
     - name: Test
       env:
+        TEST: 1
         ENABLE_COVERAGE: true
-      run: |
-        export PATH="${HOME}/.local/bin:${PATH}"
-        export TWINE_USERNAME=__token__
-        export TWINE_PASSWORD=${{ secrets.PYPI_TPM2_PYTSS }}
-        export SSH_TPM2_PYTSS_GH_PAGES=${{ secrets.SSH_TPM2_PYTSS_GH_PAGES }}
-        export ${{ matrix.check }}=1
-        ./.ci/run.sh
+      run: ./.ci/run.sh
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,13 +5,6 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      max-parallel: 4
-      matrix:
-        check: [DOCS, TEST]
-        python-version: [3.7]
-
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v2
@@ -38,6 +31,20 @@ jobs:
         export SSH_TPM2_PYTSS_GH_PAGES=${{ secrets.SSH_TPM2_PYTSS_GH_PAGES }}
         export ${{ matrix.check }}=1
         ./.ci/run.sh
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+
+    - name: Install Dependencies
+      run: docker build -t tpm2software/tpm2-tss-python -f .ci/Dockerfile.tpm2-tss-python .
+
+    - name: Check
+      env:
+        DOCS: 1
+      run: ./.ci/run.sh
 
   whitespace-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- create a publish package job and limit it to PUSH TAG events.
- set the SSH account for publishing docs to github pages branch to not @pdxjohnny.
- make testing the docs for PR's and PUSH requests only run the sphinx command (scripts/docs.sh)
- make publishing docs it's own job and limit to PUSH events.