### PR TITLE
NO MERGE: Debug path fixes

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -27,6 +27,10 @@ function run_test() {
     /bin/bash -c '/workspace/tpm2-pytss/.ci/docker.run'
 
   if [ -n "${ENABLE_COVERAGE}" ]; then
+    echo "DEBUG PWD: $PWD"
+    echo "DEBUG START DUMP"
+    "${PYTHON}" -m codecov --dump
+    echo "DEBUG END DUMP"
     "${PYTHON}" -m codecov
   fi
 

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+  - "workspace/::"        # reduce root e.g., "before/path/" => "path/"


### PR DESCRIPTION
Inside of the docker container, codecov is run at the path
/workspace/tpm2-pytss. This seems to cause coverage uploads
not to resolve as the upload path is the CI's tpm2-pytss path.

I dropped a PWD before the codecov tool so we can see the path of
the repo there.

I also added a codecov --dump so we can get the contents of
coverage.xml.

Signed-off-by: William Roberts <william.c.roberts@intel.com>