### PR TITLE
fix sphinx build for readthedocs

### DIFF
--- a/.ci/docker-prelude.sh
+++ b/.ci/docker-prelude.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 
 # all command failures are fatal
 set -e

--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 
 set -e
 

--- a/.ci/download-deps.sh
+++ b/.ci/download-deps.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 
 # TPM2 3.0.3
 export TPM2_TSS_SHA=3.0.3

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,6 +2,12 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 version: 2
+
+# stable is ubuntu-18.04 image
+#   - https://hub.docker.com/r/readthedocs/build/
+build:
+  image: stable
+
 sphinx:
   builder: html
   configuration: docs/conf.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,10 @@ from unittest.mock import patch
 
 from setuptools_scm import get_version
 
+import builtins
+
+builtins.__sphinx_build__ = True
+
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@
 import os
 import sys
 import datetime
+import subprocess
 
 from setuptools_scm import get_version
 
@@ -98,3 +99,16 @@ templates_path = ["_templates"]
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+def builder_finished_handler(app, exception):
+    if exception is None:
+        subprocess.check_call("docs/sphinx-finished.sh", shell=True)
+
+
+#
+# Hook the setup of readthedocs so we can hook into events as defined in:
+# - https://www.sphinx-doc.org/en/master/extdev/appapi.html
+#
+def setup(app):
+    app.connect("build-finished", builder_finished_handler)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,6 @@
 import os
 import sys
 import datetime
-from unittest.mock import patch
 
 from setuptools_scm import get_version
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,6 +15,7 @@ requests==2.25.1
 setuptools-scm==6.0.1
 snowballstemmer==2.1.0
 Sphinx==3.5.4
+sphinx-rtd-theme==0.5.2
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==1.0.3

--- a/docs/sphinx-finished.sh
+++ b/docs/sphinx-finished.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-License-Identifier: BSD-3
+# SPDX-License-Identifier: BSD-2
 
 #
 # This script is configured to run as part of the sphinx build

--- a/docs/sphinx-finished.sh
+++ b/docs/sphinx-finished.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3
+
+#
+# This script is configured to run as part of the sphinx build
+# through API events registered in conf.py.
+# This script runs on event build-finished.
+#
+# This would be better served by handling the events
+# html-collect-page --> for add .nojekyll
+# html-page-context --> for fixing the span's done with sed.
+#
+# For the case of time, we just left this script as is and run it as a
+# post sphinx build command event :-p
+#
+
+set -eo pipefail
+
+find pages/ -name \*.html -exec \
+  sed -i 's/<span class="gp">\&gt;\&gt;\&gt; <\/span>//g' {} \;
+touch pages/.nojekyll
+
+exit 0

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# SPDX-License-Identifier: BSD-3
+# SPDX-License-Identifier: BSD-2
 set -e
 
 sphinx-build -W -b html docs pages

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env sh
+# SPDX-License-Identifier: BSD-3
 set -e
 
-rm -rf pages
 sphinx-build -W -b html docs pages
-find pages/ -name \*.html -exec \
-  sed -i 's/<span class="gp">\&gt;\&gt;\&gt; <\/span>//g' {} \;
-touch pages/.nojekyll

--- a/scripts/prepare_headers.py
+++ b/scripts/prepare_headers.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 """
-SPDX-License-Identifier: BSD-3
+SPDX-License-Identifier: BSD-2
 """
 
 import os
@@ -179,7 +179,7 @@ def prepare(indir, outfile):
             textwrap.dedent(
                 """
             /*
-             * SPDX-License-Identifier: BSD-3
+             * SPDX-License-Identifier: BSD-2
              * This file was automatically generated. Do not modify !
              */
             """

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ dev =
     coverage
     codecov
     sphinx
+    sphinx-rtd-theme
     twine
     setuptools_scm[toml]>=3.4.3
     black==19.10b0

--- a/test/TSS2_BaseTest.py
+++ b/test/TSS2_BaseTest.py
@@ -1,5 +1,5 @@
 """
-SPDX-License-Identifier: BSD-3
+SPDX-License-Identifier: BSD-2
 """
 
 from distutils import spawn

--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -u
 """
-SPDX-License-Identifier: BSD-3
+SPDX-License-Identifier: BSD-2
 """
 import binascii
 import itertools

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -u
 """
-SPDX-License-Identifier: BSD-3
+SPDX-License-Identifier: BSD-2
 """
 
 import unittest

--- a/test/test_fapi.py
+++ b/test/test_fapi.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -u
 """
-SPDX-License-Identifier: BSD-3
+SPDX-License-Identifier: BSD-2
 """
 
 import random

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -u
 """
-SPDX-License-Identifier: BSD-3
+SPDX-License-Identifier: BSD-2
 """
 import binascii
 import itertools

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -1,5 +1,5 @@
 """
-SPDX-License-Identifier: BSD-3
+SPDX-License-Identifier: BSD-2
 """
 
 try:

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -2,7 +2,28 @@
 SPDX-License-Identifier: BSD-3
 """
 
-from ._libtpm2_pytss import lib
+try:
+    from ._libtpm2_pytss import lib
+except ModuleNotFoundError as e:
+    import builtins
+
+    in_sphinx = getattr(builtins, "__sphinx_build__", False)
+    if not in_sphinx:
+        raise e
+    import sys
+    from unittest.mock import MagicMock
+
+    class MyMagicMock(MagicMock):
+        def __repr__(self):
+            name = self._extract_mock_name()
+            name = name.replace("mock.lib.", "")
+            if name.startswith("ESYS_TR_"):
+                end = name.replace("ESYS_TR_", "")
+                name = "ESYS_TR." + end
+
+            return name
+
+    sys.modules["tpm2_pytss._libtpm2_pytss"] = MyMagicMock()
 
 from .types import *
 

--- a/tpm2_pytss/FAPI.py
+++ b/tpm2_pytss/FAPI.py
@@ -1,5 +1,5 @@
 """
-SPDX-License-Identifier: BSD-3
+SPDX-License-Identifier: BSD-2
 """
 import contextlib
 import json

--- a/tpm2_pytss/TctiLdr.py
+++ b/tpm2_pytss/TctiLdr.py
@@ -1,5 +1,5 @@
 """
-SPDX-License-Identifier: BSD-3
+SPDX-License-Identifier: BSD-2
 """
 
 from ._libtpm2_pytss import lib, ffi

--- a/tpm2_pytss/crypto.py
+++ b/tpm2_pytss/crypto.py
@@ -1,5 +1,5 @@
 """
-SPDX-License-Identifier: BSD-3
+SPDX-License-Identifier: BSD-2
 """
 
 from math import ceil

--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -1,5 +1,5 @@
 """
-SPDX-License-Identifier: BSD-3
+SPDX-License-Identifier: BSD-2
 """
 
 from ._libtpm2_pytss import ffi, lib

--- a/tpm2_pytss/utils.py
+++ b/tpm2_pytss/utils.py
@@ -1,5 +1,5 @@
 """
-SPDX-License-Identifier: BSD-3
+SPDX-License-Identifier: BSD-2
 """
 
 from ._libtpm2_pytss import ffi


### PR DESCRIPTION
I switched to readthedocs, but it's broken. The build fails to include ESAPI do to an import error, thus we Mock things since we cant pull external dependencies onto RTD build servers.

Also deal with:
- Fix SPDX identifiers
- sphinx-rtd-theme