### PR TITLE
ESAPI.py: add function to check input parameter types

### DIFF
--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -154,6 +154,10 @@ class CryptoTest(TSS2_EsapiTest):
 
         self.ectx.LoadExternal(priv, pub, types.ESYS_TR.RH_NULL)
 
+    def test_loadexternal_public_rsa(self):
+        pub = types.TPM2B_PUBLIC.fromPEM(rsa_public_key)
+        self.ectx.LoadExternal(None, pub, types.ESYS_TR.RH_NULL)
+
     def test_public_to_pem_rsa(self):
         pub = types.TPM2B_PUBLIC.fromPEM(rsa_public_key)
         pem = crypto.public_to_pem(pub.publicArea)

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -930,6 +930,20 @@ class TestEsys(TSS2_EsapiTest):
         )
         self.assertEqual(type(pcrs), TPML_DIGEST_VALUES)
 
+    def test_Vendor_TCG_Test(self):
+        with self.assertRaises(TSS2_Exception):
+            data = self.ectx.Vendor_TCG_Test(b"random data")
+
+        in_cdata = TPM2B_DATA(b"other bytes")._cdata
+        with self.assertRaises(TSS2_Exception):
+            data = self.ectx.Vendor_TCG_Test(in_cdata)
+
+        with self.assertRaises(TypeError):
+            self.ectx.Vendor_TCG_Test(None)
+
+        with self.assertRaises(TypeError):
+            self.ectx.Vendor_TCG_Test(TPM2B_PUBLIC())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
* Allows bytes instead of TPM2B_SIMPLE_OBJECT instances
* Allows None as a parameter when allow_none=True (see inPrivate for LoadExternal)
* Checks for either the correct TPM_OBJECT instance type or the correct ffi cdata instance type

The current tests uses LoadExternal in test_crypto.py and Vendor_TCG_Test which is a bit weird, I can always add more specific tests if it's wanted.

Had to add the get_cdata function to ESAPI.py instead of utils.py as types.py imports utils.py