### PR TITLE
fixup SPDX identifiers from BSD-3 to 2

### DIFF
--- a/tpm2_pytss/callbacks.py
+++ b/tpm2_pytss/callbacks.py
@@ -1,5 +1,5 @@
 """
-SPDX-License-Identifier: BSD-3
+SPDX-License-Identifier: BSD-2
 """
 
 

--- a/tpm2_pytss/constants.py
+++ b/tpm2_pytss/constants.py
@@ -1,5 +1,5 @@
 """
-SPDX-License-Identifier: BSD-3
+SPDX-License-Identifier: BSD-2
 """
 
 from enum import Enum, auto


### PR DESCRIPTION
Make it match the license.

Signed-off-by: William Roberts <william.c.roberts@intel.com>