### PR TITLE
ESAPI.py: add TR_FromTPMPublic method

### DIFF
--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -1318,6 +1318,25 @@ class TestEsys(TSS2_EsapiTest):
         with self.assertRaises(TypeError):
             self.ectx.Vendor_TCG_Test(TPM2B_PUBLIC())
 
+    def test_TR_FromTPMPublic(self):
+        nvpub = TPM2B_NV_PUBLIC(
+            nvPublic=TPMS_NV_PUBLIC(
+                nvIndex=0x1000000,
+                nameAlg=TPM2_ALG.SHA256,
+                attributes=TPMA_NV.OWNERWRITE
+                | TPMA_NV.OWNERREAD
+                | TPMA_NV.WRITE_STCLEAR,
+                authPolicy=b"",
+                dataSize=8,
+            )
+        )
+
+        self.ectx.NV_DefineSpace(ESYS_TR.RH_OWNER, b"", nvpub)
+        handle = self.ectx.TR_FromTPMPublic(nvpub.nvPublic.nvIndex)
+
+        _, name = self.ectx.NV_ReadPublic(handle)
+        self.assertEqual(bytes(nvpub.getName()), bytes(name))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -66,6 +66,26 @@ class ESAPI:
         lib.Esys_Finalize(self.ctx_pp)
         self.ctx = ffi.NULL
 
+    def TR_FromTPMPublic(
+        self,
+        handle,
+        optionalSession1=ESYS_TR.NONE,
+        optionalSession2=ESYS_TR.NONE,
+        optionalSession3=ESYS_TR.NONE,
+    ):
+        obj = ffi.new("ESYS_TR *")
+        _chkrc(
+            lib.Esys_TR_FromTPMPublic(
+                self.ctx,
+                handle,
+                optionalSession1,
+                optionalSession2,
+                optionalSession3,
+                obj,
+            )
+        )
+        return obj[0]
+
     def setAuth(self, esys_tr, auth):
 
         auth_p = TPM2B_pack(auth, "TPM2B_AUTH")


### PR DESCRIPTION
Needed by TSSPrivKey and some tests.