### PR TITLE
more esapi testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ public/
 .coverage
 *.orig
 *.rej
+htmlcov

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ pages/
 public/
 *.h
 .coverage
+*.orig
+*.rej

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ setup_requires =
 install_requires =
     cffi>=1.0.0
     asn1crypto
+    pkgconfig
 
 [options.extras_require]
 dev =

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -268,6 +268,24 @@ class TestEsys(TSS2_EsapiTest):
         random = self.ectx.GetRandom(4, session1=session)
         self.assertEqual(len(random), 4)
 
+    def test_start_authSession_noncecaller_bad(self):
+
+        sym = TPMT_SYM_DEF(
+            algorithm=TPM2_ALG.XOR,
+            keyBits=TPMU_SYM_KEY_BITS(exclusiveOr=TPM2_ALG.SHA256),
+            mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
+        )
+
+        with self.assertRaises(TypeError):
+            self.ectx.StartAuthSession(
+                tpmKey=ESYS_TR.NONE,
+                bind=ESYS_TR.NONE,
+                nonceCaller=object(),
+                sessionType=TPM2_SE.HMAC,
+                symmetric=sym,
+                authHash=TPM2_ALG.SHA256,
+            )
+
     def test_create(self):
 
         alg = "rsa2048:aes128cfb"

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -1481,6 +1481,31 @@ class TestEsys(TSS2_EsapiTest):
             self.ectx.FirmwareRead(0)
         self.assertEqual(e.exception.error, TPM2_RC.COMMAND_CODE)
 
+    def test_shutdown_no_arg(self):
+        self.ectx.Shutdown(TPM2_SU.STATE)
+
+    def test_shutdown_state(self):
+        self.ectx.Shutdown(TPM2_SU.STATE)
+
+    def test_shutdown_clear(self):
+        self.ectx.Shutdown(TPM2_SU.CLEAR)
+
+    def test_shutdown_bad(self):
+        with self.assertRaises(TypeError):
+            self.ectx.Shutdown(object())
+
+        with self.assertRaises(ValueError):
+            self.ectx.Shutdown(42)
+
+        with self.assertRaises(TypeError):
+            self.ectx.Shutdown(session1=object())
+
+        with self.assertRaises(TypeError):
+            self.ectx.Shutdown(session2=object())
+
+        with self.assertRaises(TypeError):
+            self.ectx.Shutdown(session3=object())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -1524,6 +1524,37 @@ class TestEsys(TSS2_EsapiTest):
         with self.assertRaises(TypeError):
             self.ectx.Shutdown(session3=object())
 
+    def test_policyrestart(self):
+
+        sym = TPMT_SYM_DEF(
+            algorithm=TPM2_ALG.XOR,
+            keyBits=TPMU_SYM_KEY_BITS(exclusiveOr=TPM2_ALG.SHA256),
+            mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
+        )
+
+        session = self.ectx.StartAuthSession(
+            tpmKey=ESYS_TR.NONE,
+            bind=ESYS_TR.NONE,
+            nonceCaller=None,
+            sessionType=TPM2_SE.TRIAL,
+            symmetric=sym,
+            authHash=TPM2_ALG.SHA256,
+        )
+
+        self.ectx.PolicyRestart(session)
+
+        with self.assertRaises(TypeError):
+            self.ectx.PolicyRestart(object())
+
+        with self.assertRaises(TypeError):
+            self.ectx.PolicyRestart(session, session1=4.5)
+
+        with self.assertRaises(TypeError):
+            self.ectx.PolicyRestart(session, session2=object())
+
+        with self.assertRaises(TypeError):
+            self.ectx.PolicyRestart(session, session3=33.666)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_fapi.py
+++ b/test/test_fapi.py
@@ -6,6 +6,8 @@ SPDX-License-Identifier: BSD-2
 import random
 import string
 
+import pkgconfig
+
 import pytest
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -312,9 +314,12 @@ class TestFapi:
         assert imported is True
         assert key_path in self.fapi.list()
 
-        self.fapi.import_object(path=key_path, import_data=key_public_pem)
         # assert imported is False  # TODO bug: tpm2-tss #2028, fixed in master
-        assert imported is True
+        if pkgconfig.installed("tss2-fapi", ">=3.1.0"):
+            with pytest.raises(TSS2_Exception):
+                self.fapi.import_object(path=key_path, import_data=key_public_pem)
+        else:
+            self.fapi.import_object(path=key_path, import_data=key_public_pem)
 
     def test_import_policy_double_ok(self):
         policy = """
@@ -343,9 +348,12 @@ class TestFapi:
         assert imported is True
         assert policy_path in self.fapi.list()
 
-        self.fapi.import_object(path=policy_path, import_data=policy)
         # assert imported is False  # TODO bug: tpm2-tss #2028, fixed in master
-        assert imported is True
+        if pkgconfig.installed("tss2-fapi", ">=3.1.0"):
+            with pytest.raises(TSS2_Exception):
+                self.fapi.import_object(path=policy_path, import_data=policy)
+        else:
+            self.fapi.import_object(path=policy_path, import_data=policy)
 
     def test_import_exported_key(self, sign_key):
         exported_data = self.fapi.export_key(path=sign_key)

--- a/test/test_fapi.py
+++ b/test/test_fapi.py
@@ -265,7 +265,9 @@ class TestFapi:
         self.fapi.verify_signature(sign_key, digest, signature)
 
         # verify via openssl
-        public_key = serialization.load_pem_public_key(key_public_pem)
+        public_key = serialization.load_pem_public_key(
+            key_public_pem, backend=default_backend()
+        )
         public_key.verify(signature, message, ec.ECDSA(hashes.SHA256()))
 
     def test_verify(self, ext_key):

--- a/test/test_fapi.py
+++ b/test/test_fapi.py
@@ -68,7 +68,7 @@ def init_fapi(request, fapi):
 class TestFapi:
     @pytest.fixture
     def cryptography_key(self):
-        key = ec.generate_private_key(ec.SECP256R1())
+        key = ec.generate_private_key(ec.SECP256R1(), backend=default_backend())
         key_public_pem = key.public_key().public_bytes(
             encoding=serialization.Encoding.PEM,
             format=serialization.PublicFormat.SubjectPublicKeyInfo,

--- a/test/test_fapi.py
+++ b/test/test_fapi.py
@@ -9,6 +9,7 @@ import string
 import pytest
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.backends import default_backend
 
 from tpm2_pytss import *
 
@@ -45,7 +46,7 @@ def random_uid() -> str:
 
 def sha256(data: bytes) -> bytes:
     """Calculate the SHA256 digest of given data."""
-    digest = hashes.Hash(hashes.SHA256())
+    digest = hashes.Hash(hashes.SHA256(), backend=default_backend())
     digest.update(data)
     digest = digest.finalize()
     return digest

--- a/test/test_fapi.py
+++ b/test/test_fapi.py
@@ -250,7 +250,7 @@ class TestFapi:
     def test_sign(self, sign_key):
         # create signature
         message = b"Hello World"
-        digest = hashes.Hash(hashes.SHA256())
+        digest = hashes.Hash(hashes.SHA256(), backend=default_backend())
         digest.update(message)
         digest = digest.finalize()
 

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -177,10 +177,10 @@ class ESAPI:
 
         if nonceCaller is None:
             nonceCaller = ffi.NULL
-        elif isinstance(nonceCaller, TPM_OBJECT):
+        elif isinstance(nonceCaller, TPM2B_NONCE):
             nonceCaller = nonceCaller._cdata
         else:
-            raise TypeError("Expected nonceCaller to be None or TPM_OBJECT")
+            raise TypeError("Expected nonceCaller to be None or TPM2B_NONCE")
 
         sessionHandle = ffi.new("ESYS_TR *")
         _chkrc(

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -213,6 +213,11 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
+        check_handle_type(sessionHandle, "sessionHandle")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
         _chkrc(
             lib.Esys_PolicyRestart(
                 self.ctx, sessionHandle, session1, session2, session3

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -101,11 +101,25 @@ class ESAPI:
 
     def Shutdown(
         self,
-        shutdownType,
+        shutdownType=TPM2_SU.STATE,
         session1=ESYS_TR.NONE,
         session2=ESYS_TR.NONE,
         session3=ESYS_TR.NONE,
     ):
+
+        if not isinstance(shutdownType, int):
+            raise TypeError(
+                f"Expected shutdownType to be int, got {type(shutdownType)}"
+            )
+
+        if shutdownType not in [TPM2_SU.STATE, TPM2_SU.CLEAR]:
+            raise ValueError(
+                f"Expected shutdownType to be TPM2_SU.STATE or TPM2_SU.CLEAR, got {shutdownType}"
+            )
+
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
 
         _chkrc(lib.Esys_Shutdown(self.ctx, session1, session2, session3, shutdownType))
 


### PR DESCRIPTION
- test: FAPI fix tests against master
- test: fix FAPI generate_private_key() missing argument: 'backend'
- test: FAPI fix load_pem_public_key() missing 'backend'
- test: FAPI fix __init__() missing argument: 'backend'
- test: ESAPI PolicyRestart
- test: FAPI fix __init__() missing argument 'backend'
- test: ESAPI StartAuthSession with bad nonce
- ESAPI: StartAuthSession nonceCaller should be TPM2B_NONCE
- test: ESAPI Shutdown
- gitignore: pycoverage htmlcov report dir
- gitignore: .rej and .orig patch files