### PR TITLE
ESAPI Testing PolicyGetDigest, PolicyCC, PolicyAuth, and Duplicate

### DIFF
--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -1713,6 +1713,34 @@ class TestEsys(TSS2_EsapiTest):
         with self.assertRaises(TypeError):
             self.ectx.PolicyAuthValue(b"1234")
 
+    def test_PolicyCommandCode(self):
+
+        sym = TPMT_SYM_DEF(
+            algorithm=TPM2_ALG.XOR,
+            keyBits=TPMU_SYM_KEY_BITS(exclusiveOr=TPM2_ALG.SHA256),
+            mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
+        )
+
+        session = self.ectx.StartAuthSession(
+            tpmKey=ESYS_TR.NONE,
+            bind=ESYS_TR.NONE,
+            nonceCaller=None,
+            sessionType=TPM2_SE.TRIAL,
+            symmetric=sym,
+            authHash=TPM2_ALG.SHA256,
+        )
+
+        self.ectx.PolicyCommandCode(session, TPM2_CC.Duplicate)
+
+        with self.assertRaises(TypeError):
+            self.ectx.PolicyCommandCode(b"1234", TPM2_CC.Duplicate)
+
+        with self.assertRaises(TypeError):
+            self.ectx.PolicyCommandCode(session, b"12345")
+
+        with self.assertRaises(ValueError):
+            self.ectx.PolicyCommandCode(session, 42)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -1741,6 +1741,28 @@ class TestEsys(TSS2_EsapiTest):
         with self.assertRaises(ValueError):
             self.ectx.PolicyCommandCode(session, 42)
 
+    def test_PolicyGetDigest(self):
+
+        sym = TPMT_SYM_DEF(
+            algorithm=TPM2_ALG.XOR,
+            keyBits=TPMU_SYM_KEY_BITS(exclusiveOr=TPM2_ALG.SHA256),
+            mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
+        )
+
+        session = self.ectx.StartAuthSession(
+            tpmKey=ESYS_TR.NONE,
+            bind=ESYS_TR.NONE,
+            nonceCaller=None,
+            sessionType=TPM2_SE.TRIAL,
+            symmetric=sym,
+            authHash=TPM2_ALG.SHA256,
+        )
+
+        self.ectx.PolicyAuthValue(session)
+        self.ectx.PolicyCommandCode(session, TPM2_CC.Duplicate)
+        policyDigest = self.ectx.PolicyGetDigest(session)
+        self.assertTrue(type(policyDigest), TPM2B_DIGEST)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -1691,6 +1691,28 @@ class TestEsys(TSS2_EsapiTest):
                 session3="foo",
             )
 
+    def test_PolicyAuthValue(self):
+
+        sym = TPMT_SYM_DEF(
+            algorithm=TPM2_ALG.XOR,
+            keyBits=TPMU_SYM_KEY_BITS(exclusiveOr=TPM2_ALG.SHA256),
+            mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
+        )
+
+        session = self.ectx.StartAuthSession(
+            tpmKey=ESYS_TR.NONE,
+            bind=ESYS_TR.NONE,
+            nonceCaller=None,
+            sessionType=TPM2_SE.TRIAL,
+            symmetric=sym,
+            authHash=TPM2_ALG.SHA256,
+        )
+
+        self.ectx.PolicyAuthValue(session)
+
+        with self.assertRaises(TypeError):
+            self.ectx.PolicyAuthValue(b"1234")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -1555,6 +1555,142 @@ class TestEsys(TSS2_EsapiTest):
         with self.assertRaises(TypeError):
             self.ectx.PolicyRestart(session, session3=33.666)
 
+    def test_duplicate(self):
+
+        sym = TPMT_SYM_DEF(
+            algorithm=TPM2_ALG.XOR,
+            keyBits=TPMU_SYM_KEY_BITS(exclusiveOr=TPM2_ALG.SHA256),
+            mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
+        )
+
+        session = self.ectx.StartAuthSession(
+            tpmKey=ESYS_TR.NONE,
+            bind=ESYS_TR.NONE,
+            nonceCaller=None,
+            sessionType=TPM2_SE.TRIAL,
+            symmetric=sym,
+            authHash=TPM2_ALG.SHA256,
+        )
+
+        self.ectx.PolicyAuthValue(session)
+        self.ectx.PolicyCommandCode(session, TPM2_CC.Duplicate)
+        policyDigest = self.ectx.PolicyGetDigest(session)
+        self.ectx.FlushContext(session)
+        session = None
+
+        inPublic = TPM2B_PUBLIC(
+            TPMT_PUBLIC.parse(
+                alg="rsa2048",
+                objectAttributes=TPMA_OBJECT.USERWITHAUTH
+                | TPMA_OBJECT.RESTRICTED
+                | TPMA_OBJECT.DECRYPT
+                | TPMA_OBJECT.FIXEDTPM
+                | TPMA_OBJECT.FIXEDPARENT
+                | TPMA_OBJECT.SENSITIVEDATAORIGIN,
+            )
+        )
+
+        inSensitive = TPM2B_SENSITIVE_CREATE()
+
+        outsideInfo = TPM2B_DATA()
+        creationPCR = TPML_PCR_SELECTION()
+
+        primary1, _, _, _, _ = self.ectx.CreatePrimary(
+            ESYS_TR.OWNER, inSensitive, inPublic, outsideInfo, creationPCR
+        )
+
+        primary2, _, _, _, _ = self.ectx.CreatePrimary(
+            ESYS_TR.OWNER, inSensitive, inPublic, outsideInfo, creationPCR
+        )
+
+        inPublic = TPM2B_PUBLIC(
+            TPMT_PUBLIC.parse(
+                alg="rsa2048:aes128cfb",
+                objectAttributes=TPMA_OBJECT.USERWITHAUTH
+                | TPMA_OBJECT.RESTRICTED
+                | TPMA_OBJECT.DECRYPT
+                | TPMA_OBJECT.SENSITIVEDATAORIGIN,
+            )
+        )
+        inPublic.publicArea.authPolicy = policyDigest
+
+        priv, pub, _, _, _ = self.ectx.Create(
+            primary1, inSensitive, inPublic, outsideInfo, creationPCR
+        )
+
+        childHandle = self.ectx.Load(primary1, priv, pub)
+
+        session = self.ectx.StartAuthSession(
+            tpmKey=ESYS_TR.NONE,
+            bind=ESYS_TR.NONE,
+            nonceCaller=None,
+            sessionType=TPM2_SE.POLICY,
+            symmetric=sym,
+            authHash=TPM2_ALG.SHA256,
+        )
+
+        self.ectx.PolicyAuthValue(session)
+        self.ectx.PolicyCommandCode(session, TPM2_CC.Duplicate)
+
+        encryptionKey = TPM2B_DATA("is sixteen bytes")
+
+        sym = TPMT_SYM_DEF_OBJECT(
+            algorithm=TPM2_ALG.AES,
+            keyBits=TPMU_SYM_KEY_BITS(aes=128),
+            mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
+        )
+
+        encryptionKeyOut, duplicate, symSeed = self.ectx.Duplicate(
+            childHandle, primary2, encryptionKey, sym, session1=session
+        )
+        self.assertEqual(type(encryptionKeyOut), TPM2B_DATA)
+        self.assertEqual(type(duplicate), TPM2B_PRIVATE)
+        self.assertEqual(type(symSeed), TPM2B_ENCRYPTED_SECRET)
+
+        with self.assertRaises(TypeError):
+            self.ectx.Duplicate(6.7, primary2, encryptionKey, sym, session1=session)
+
+        with self.assertRaises(TypeError):
+            self.ectx.Duplicate(
+                childHandle, object(), encryptionKey, sym, session1=session
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.Duplicate(
+                childHandle, primary2, TPM2B_PUBLIC(), sym, session1=session
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.Duplicate(
+                childHandle, primary2, encryptionKey, b"1234", session1=session
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.Duplicate(
+                childHandle, primary2, encryptionKey, sym, session1=7.89
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.Duplicate(
+                childHandle,
+                primary2,
+                encryptionKey,
+                sym,
+                session1=session,
+                session2="foo",
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.Duplicate(
+                childHandle,
+                primary2,
+                encryptionKey,
+                sym,
+                session1=session,
+                session2=ESYS_TR.PASSWORD,
+                session3="foo",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -1205,6 +1205,12 @@ class TypesTest(unittest.TestCase):
         self.assertEqual(templ.type, TPM2_ALG.RSA)
         self.assertEqual(templ2.type, TPM2_ALG.KEYEDHASH)
 
+    def test_TPM_FRIENDLY_INT_iterator(self):
+        self.assertNotEqual(len(list(TPM2_CC.iterator())), 0)
+
+    def test_TPM_FRIENDLY_INT_contains(self):
+        self.assertTrue(TPM2_CC.contains(TPM2_CC.AC_Send))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -47,6 +47,17 @@ def check_handle_type(handle, varname):
         )
 
 
+def check_friendly_int(friendly, varname, clazz):
+
+    if not isinstance(friendly, int):
+        raise TypeError(f"expected {varname} to be type int, got {type(friendly)}")
+
+    if not clazz.contains(friendly):
+        raise ValueError(
+            f"expected {varname} value of {friendly} in class {str(clazz)}, however it's not found."
+        )
+
+
 class ESAPI:
     def __init__(self, tcti=None):
 
@@ -494,6 +505,19 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
+        check_handle_type(objectHandle, "objectHandle")
+        check_handle_type(newParentHandle, "newParentHandle")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
+        encryptionKeyIn_cdata = get_cdata(
+            encryptionKeyIn, TPM2B_DATA, "encryptionKeyIn"
+        )
+        symmetricAlg_cdata = get_cdata(
+            symmetricAlg, TPMT_SYM_DEF_OBJECT, "symmetricAlg"
+        )
+
         encryptionKeyOut = ffi.new("TPM2B_DATA **")
         duplicate = ffi.new("TPM2B_PRIVATE **")
         outSymSeed = ffi.new("TPM2B_ENCRYPTED_SECRET **")
@@ -505,14 +529,19 @@ class ESAPI:
                 session1,
                 session2,
                 session3,
-                encryptionKeyIn,
-                symmetricAlg,
+                encryptionKeyIn_cdata,
+                symmetricAlg_cdata,
                 encryptionKeyOut,
                 duplicate,
                 outSymSeed,
             )
         )
-        return (get_ptr(encryptionKeyOut), get_ptr(duplicate), get_ptr(outSymSeed))
+
+        return (
+            TPM2B_DATA(get_ptr(encryptionKeyOut)),
+            TPM2B_PRIVATE(get_ptr(duplicate)),
+            TPM2B_ENCRYPTED_SECRET(get_ptr(outSymSeed)),
+        )
 
     def Rewrap(
         self,
@@ -1718,6 +1747,12 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
+        check_handle_type(policySession, "policySession")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+        check_friendly_int(code, "code", TPM2_CC)
+
         _chkrc(
             lib.Esys_PolicyCommandCode(
                 self.ctx, policySession, session1, session2, session3, code
@@ -1826,6 +1861,11 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
+        check_handle_type(policySession, "policySession")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
         _chkrc(
             lib.Esys_PolicyAuthValue(
                 self.ctx, policySession, session1, session2, session3
@@ -1854,13 +1894,18 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
+        check_handle_type(policySession, "policySession")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
         policyDigest = ffi.new("TPM2B_DIGEST **")
         _chkrc(
             lib.Esys_PolicyGetDigest(
                 self.ctx, policySession, session1, session2, session3, policyDigest
             )
         )
-        return get_ptr(policyDigest)
+        return TPM2B_DIGEST(get_ptr(policyDigest))
 
     def PolicyNvWritten(
         self,

--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -40,6 +40,14 @@ class TPM_FRIENDLY_INT(int):
 
         return value
 
+    @classmethod
+    def iterator(cls):
+        return filter(lambda x: isinstance(x, int), vars(cls).values())
+
+    @classmethod
+    def contains(cls, value):
+        return value in cls.iterator()
+
 
 class TPM_FRIENDLY_INTLIST(TPM_FRIENDLY_INT):
     @classmethod


### PR DESCRIPTION
- test: ESAPI PolicyGetDigest
- test: ESAPI PolicyCommandCode
- test: ESAPI PolicyAuthValue
- test: ESAPI Duplicate
- types: add iterator and contains to friendly int
