### PR TITLE
Esapi testing (Quote) and API changes to CreatePrimary and Create Plus lots of checks/tests added

### DIFF
--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -163,7 +163,31 @@ class CryptoTest(TSS2_EsapiTest):
 
         priv = types.TPM2B_SENSITIVE.fromPEM(rsa_private_key)
 
-        self.ectx.LoadExternal(priv, pub, types.ESYS_TR.RH_NULL)
+        # test without Hierarchy
+        handle = self.ectx.LoadExternal(priv, pub)
+        self.assertNotEqual(handle, 0)
+
+        # negative test
+        with self.assertRaises(TypeError):
+            self.ectx.LoadExternal(TPM2B_PUBLIC(), pub)
+
+        with self.assertRaises(TypeError):
+            self.ectx.LoadExternal(priv, priv)
+
+        with self.assertRaises(ValueError):
+            self.ectx.LoadExternal(priv, pub, 7467644)
+
+        with self.assertRaises(TypeError):
+            self.ectx.LoadExternal(priv, pub, object)
+
+        with self.assertRaises(TypeError):
+            self.ectx.LoadExternal(priv, pub, session1=76.5)
+
+        with self.assertRaises(TypeError):
+            self.ectx.LoadExternal(priv, pub, session2=object())
+
+        with self.assertRaises(TypeError):
+            self.ectx.LoadExternal(priv, pub, session3=TPM2B_PUBLIC())
 
     def test_public_from_pem_ecc(self):
         pub = types.TPM2B_PUBLIC()

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -1364,6 +1364,27 @@ class TestEsys(TSS2_EsapiTest):
         self.assertNotEqual(hmac, None)
         self.assertEqual(len(bytes(hmac)), 32)
 
+        with self.assertRaises(TypeError):
+            self.ectx.HMAC(45.6, inData, TPM2_ALG.SHA256)
+
+        with self.assertRaises(TypeError):
+            self.ectx.HMAC(primaryHandle, object(), TPM2_ALG.SHA256)
+
+        with self.assertRaises(TypeError):
+            self.ectx.HMAC(primaryHandle, inData, "baz")
+
+        with self.assertRaises(ValueError):
+            self.ectx.HMAC(primaryHandle, inData, 42)
+
+        with self.assertRaises(TypeError):
+            self.ectx.HMAC(primaryHandle, inData, TPM2_ALG.SHA256, session1=object())
+
+        with self.assertRaises(TypeError):
+            self.ectx.HMAC(primaryHandle, inData, TPM2_ALG.SHA256, session2="object")
+
+        with self.assertRaises(TypeError):
+            self.ectx.HMAC(primaryHandle, inData, TPM2_ALG.SHA256, session3=45.6)
+
     def test_StirRandom(self):
 
         self.ectx.StirRandom(b"1234")

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -2117,7 +2117,19 @@ class TestEsys(TSS2_EsapiTest):
             self.ectx.Rewrap(primary2, primary1, duplicate, TPM2B_PRIVATE(), symSeed)
 
         with self.assertRaises(TypeError):
-            self.ectx.Rewrap(primary2, primary1, duplicate, keyName, TPMT_PUBLIC())
+            self.ectx.Rewrap(
+                primary2, primary1, duplicate, keyName, symSeed, session1="goo"
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.Rewrap(
+                primary2, primary1, duplicate, keyName, symSeed, session2=45.6
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.Rewrap(
+                primary2, primary1, duplicate, keyName, symSeed, sesion3=object()
+            )
 
     def test_Import(self):
 

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -2101,23 +2101,76 @@ class TestEsys(TSS2_EsapiTest):
         self.assertEqual(type(signature), TPMT_SIGNATURE)
 
         with self.assertRaises(TypeError):
-            certifyInfo, signature = self.ectx.Certify(
-                TPM2B_ATTEST(), eccHandle, qualifyingData, inScheme
+            self.ectx.CertifyCreation(
+                45.6, eccHandle, qualifyingData, creationHash, inScheme, creationTicket
             )
 
         with self.assertRaises(TypeError):
-            certifyInfo, signature = self.ectx.Certify(
-                eccHandle, 2.0, qualifyingData, inScheme
+            self.ectx.CertifyCreation(
+                eccHandle,
+                object(),
+                qualifyingData,
+                creationHash,
+                inScheme,
+                creationTicket,
             )
 
         with self.assertRaises(TypeError):
-            certifyInfo, signature = self.ectx.Certify(
-                eccHandle, eccHandle, TPM2B_PUBLIC(), inScheme
+            self.ectx.CertifyCreation(
+                eccHandle,
+                eccHandle,
+                TPM2B_PUBLIC(),
+                creationHash,
+                inScheme,
+                creationTicket,
             )
 
         with self.assertRaises(TypeError):
-            certifyInfo, signature = self.ectx.Certify(
-                eccHandle, eccHandle, qualifyingData, TPM2B_PRIVATE()
+            self.ectx.CertifyCreation(
+                eccHandle, eccHandle, qualifyingData, object(), inScheme, creationTicket
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.CertifyCreation(
+                eccHandle, eccHandle, qualifyingData, creationHash, [], creationTicket
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.CertifyCreation(
+                eccHandle, eccHandle, qualifyingData, creationHash, inScheme, 56.7
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.CertifyCreation(
+                eccHandle,
+                eccHandle,
+                qualifyingData,
+                creationHash,
+                inScheme,
+                creationTicket,
+                session1=56.7,
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.CertifyCreation(
+                eccHandle,
+                eccHandle,
+                qualifyingData,
+                creationHash,
+                inScheme,
+                creationTicket,
+                session2=object(),
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.CertifyCreation(
+                eccHandle,
+                eccHandle,
+                qualifyingData,
+                creationHash,
+                inScheme,
+                creationTicket,
+                session3="baz",
             )
 
     def test_Vendor_TCG_Test(self):

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -1140,7 +1140,6 @@ class TestEsys(TSS2_EsapiTest):
         outCipherText, outIV = self.ectx.EncryptDecrypt(
             aesKeyHandle, False, TPM2_ALG.CFB, ivIn, inData
         )
-
         self.assertEqual(len(outIV), len(ivIn))
 
         outData, outIV2 = self.ectx.EncryptDecrypt(
@@ -1148,6 +1147,57 @@ class TestEsys(TSS2_EsapiTest):
         )
         self.assertEqual(bytes(inData), bytes(outData))
         self.assertEqual(bytes(outIV), bytes(outIV2))
+
+        # test plain bytes for data
+        ivIn = b"thisis16byteszxc"
+        inData = b"this is data to encrypt"
+        outCipherText, outIV = self.ectx.EncryptDecrypt(
+            aesKeyHandle, False, TPM2_ALG.CFB, ivIn, inData
+        )
+        self.assertEqual(len(outIV), len(ivIn))
+
+        outData, outIV2 = self.ectx.EncryptDecrypt(
+            aesKeyHandle, True, TPM2_ALG.CFB, ivIn, outCipherText
+        )
+        self.assertEqual(inData, bytes(outData))
+        self.assertEqual(bytes(outIV), bytes(outIV2))
+
+        with self.assertRaises(TypeError):
+            self.ectx.EncryptDecrypt(42.5, True, TPM2_ALG.CFB, ivIn, outCipherText)
+
+        with self.assertRaises(TypeError):
+            self.ectx.EncryptDecrypt(
+                aesKeyHandle, object(), TPM2_ALG.CFB, ivIn, outCipherText
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.EncryptDecrypt(aesKeyHandle, True, object(), ivIn, outCipherText)
+
+        with self.assertRaises(ValueError):
+            self.ectx.EncryptDecrypt(aesKeyHandle, True, 42, ivIn, outCipherText)
+
+        with self.assertRaises(TypeError):
+            self.ectx.EncryptDecrypt(
+                aesKeyHandle, True, TPM2_ALG.CFB, TPM2B_PUBLIC(), outCipherText
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.EncryptDecrypt(aesKeyHandle, True, TPM2_ALG.CFB, ivIn, None)
+
+        with self.assertRaises(TypeError):
+            self.ectx.EncryptDecrypt(
+                aesKeyHandle, True, TPM2_ALG.CFB, ivIn, outCipherText, session1=object()
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.EncryptDecrypt(
+                aesKeyHandle, True, TPM2_ALG.CFB, ivIn, outCipherText, session2="foo"
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.EncryptDecrypt(
+                aesKeyHandle, True, TPM2_ALG.CFB, ivIn, outCipherText, session3=12.3
+            )
 
     def test_EncryptDecrypt2(self):
 

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -562,6 +562,18 @@ class TestEsys(TSS2_EsapiTest):
         self.assertTrue(name.size, 32)
         self.assertTrue(qname.size, 32)
 
+        with self.assertRaises(TypeError):
+            self.ectx.ReadPublic(object())
+
+        with self.assertRaises(TypeError):
+            self.ectx.ReadPublic(childHandle, session1=object)
+
+        with self.assertRaises(TypeError):
+            self.ectx.ReadPublic(childHandle, session2="foo")
+
+        with self.assertRaises(TypeError):
+            self.ectx.ReadPublic(childHandle, session3=42.5)
+
     def test_makecredential(self):
 
         inSensitive = TPM2B_SENSITIVE_CREATE(

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -340,22 +340,61 @@ class TestEsys(TSS2_EsapiTest):
         )
 
         alg = "rsa2048"
-        attrs = TPMA_OBJECT.DEFAULT_TPM2_TOOLS_CREATE_ATTRS
-        childInPublic = TPM2B_PUBLIC(TPMT_PUBLIC.parse(alg=alg, objectAttributes=attrs))
+        childInPublic = TPM2B_PUBLIC(TPMT_PUBLIC.parse(alg))
         outsideInfo = TPM2B_DATA()
         creationPCR = TPML_PCR_SELECTION()
 
         priv, pub, _, _, _ = self.ectx.Create(
             parentHandle, childInSensitive, childInPublic, outsideInfo, creationPCR
         )
+        self.assertEqual(type(priv), TPM2B_PRIVATE),
+        self.assertEqual(type(pub), TPM2B_PUBLIC),
 
-        self.assertTrue(
-            isinstance(priv, TPM2B_PRIVATE),
-            f"Expected TPM2B_PRIVATE, got: {type(priv)}",
+        priv, pub, _, _, _ = self.ectx.Create(
+            parentHandle, childInSensitive, childInPublic, outsideInfo
         )
-        self.assertTrue(
-            isinstance(pub, TPM2B_PUBLIC), f"Expected TPM2B_PUBLIC, got: {type(pub)}"
+        self.assertEqual(type(priv), TPM2B_PRIVATE),
+        self.assertEqual(type(pub), TPM2B_PUBLIC),
+
+        priv, pub, _, _, _ = self.ectx.Create(
+            parentHandle, childInSensitive, childInPublic, creationPCR=creationPCR
         )
+        self.assertEqual(type(priv), TPM2B_PRIVATE),
+        self.assertEqual(type(pub), TPM2B_PUBLIC),
+
+        priv, pub, _, _, _ = self.ectx.Create(
+            parentHandle,
+            childInSensitive,
+            childInPublic,
+            creationPCR="sha256:1,2,3,4,5",
+        )
+        self.assertEqual(type(priv), TPM2B_PRIVATE),
+        self.assertEqual(type(pub), TPM2B_PUBLIC),
+
+        with self.assertRaises(TypeError):
+            self.ectx.Create(
+                34.945, childInSensitive, childInPublic, outsideInfo, creationPCR
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.Create(
+                parentHandle, object(), childInPublic, outsideInfo, creationPCR
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.Create(
+                parentHandle, childInSensitive, 56, outsideInfo, creationPCR
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.Create(
+                parentHandle, childInSensitive, childInPublic, None, creationPCR
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.Create(
+                parentHandle, childInSensitive, childInPublic, outsideInfo, object
+            )
 
     def test_load(self):
 
@@ -371,15 +410,7 @@ class TestEsys(TSS2_EsapiTest):
             TPMS_SENSITIVE_CREATE(userAuth=TPM2B_AUTH("childpassword"))
         )
 
-        alg = "rsa2048"
-        attrs = TPMA_OBJECT.DEFAULT_TPM2_TOOLS_CREATE_ATTRS
-        childInPublic = TPM2B_PUBLIC(TPMT_PUBLIC.parse(alg=alg, objectAttributes=attrs))
-        outsideInfo = TPM2B_DATA()
-        creationPCR = TPML_PCR_SELECTION()
-
-        priv, pub, _, _, _ = self.ectx.Create(
-            parentHandle, childInSensitive, childInPublic, outsideInfo, creationPCR
-        )
+        priv, pub, _, _, _ = self.ectx.Create(parentHandle, childInSensitive)
 
         childHandle = self.ectx.Load(parentHandle, priv, pub)
         self.assertTrue(childHandle)
@@ -398,15 +429,7 @@ class TestEsys(TSS2_EsapiTest):
             TPMS_SENSITIVE_CREATE(userAuth=TPM2B_AUTH("childpassword"))
         )
 
-        alg = "rsa2048"
-        attrs = TPMA_OBJECT.DEFAULT_TPM2_TOOLS_CREATE_ATTRS
-        childInPublic = TPM2B_PUBLIC(TPMT_PUBLIC.parse(alg=alg, objectAttributes=attrs))
-        outsideInfo = TPM2B_DATA()
-        creationPCR = TPML_PCR_SELECTION()
-
-        priv, pub, _, _, _ = self.ectx.Create(
-            parentHandle, childInSensitive, childInPublic, outsideInfo, creationPCR
-        )
+        priv, pub, _, _, _ = self.ectx.Create(parentHandle, childInSensitive)
 
         childHandle = self.ectx.Load(parentHandle, priv, pub)
 
@@ -448,11 +471,9 @@ class TestEsys(TSS2_EsapiTest):
         childInSensitive = TPM2B_SENSITIVE_CREATE(
             TPMS_SENSITIVE_CREATE(userAuth=TPM2B_AUTH("childpassword"))
         )
-        outsideInfo = TPM2B_DATA()
-        creationPCR = TPML_PCR_SELECTION()
 
         priv, pub, _, _, _ = self.ectx.Create(
-            parentHandle, childInSensitive, childInPublic, outsideInfo, creationPCR
+            parentHandle, childInSensitive, childInPublic
         )
 
         childHandle = self.ectx.Load(parentHandle, priv, pub)
@@ -503,11 +524,9 @@ class TestEsys(TSS2_EsapiTest):
                 data=TPM2B_SENSITIVE_DATA(b"sealedsecret"),
             )
         )
-        outsideInfo = TPM2B_DATA()
-        creationPCR = TPML_PCR_SELECTION()
 
         priv, pub, _, _, _ = self.ectx.Create(
-            parentHandle, childInSensitive, childInPublic, outsideInfo, creationPCR
+            parentHandle, childInSensitive, childInPublic
         )
 
         childHandle = self.ectx.Load(parentHandle, priv, pub)
@@ -538,11 +557,9 @@ class TestEsys(TSS2_EsapiTest):
         childInSensitive = TPM2B_SENSITIVE_CREATE(
             TPMS_SENSITIVE_CREATE(userAuth=TPM2B_AUTH("childpassword"))
         )
-        outsideInfo = TPM2B_DATA()
-        creationPCR = TPML_PCR_SELECTION()
 
         priv, pub, _, _, _ = self.ectx.Create(
-            parentHandle, childInSensitive, childInPublic, outsideInfo, creationPCR
+            parentHandle, childInSensitive, childInPublic
         )
 
         childHandle = self.ectx.Load(parentHandle, priv, pub)
@@ -1582,12 +1599,8 @@ class TestEsys(TSS2_EsapiTest):
             )
         )
         inPublic.publicArea.authPolicy = policyDigest
-        outsideInfo = TPM2B_DATA()
-        creationPCR = TPML_PCR_SELECTION()
 
-        priv, pub, _, _, _ = self.ectx.Create(
-            primary1, inSensitive, inPublic, outsideInfo, creationPCR
-        )
+        priv, pub, _, _, _ = self.ectx.Create(primary1, inSensitive, inPublic)
 
         childHandle = self.ectx.Load(primary1, priv, pub)
 
@@ -1785,12 +1798,8 @@ class TestEsys(TSS2_EsapiTest):
             )
         )
         inPublic.publicArea.authPolicy = policyDigest
-        outsideInfo = TPM2B_DATA()
-        creationPCR = TPML_PCR_SELECTION()
 
-        priv, pub, _, _, _ = self.ectx.Create(
-            primary1, inSensitive, inPublic, outsideInfo, creationPCR
-        )
+        priv, pub, _, _, _ = self.ectx.Create(primary1, inSensitive, inPublic)
 
         childHandle = self.ectx.Load(primary1, priv, pub)
 
@@ -1891,12 +1900,8 @@ class TestEsys(TSS2_EsapiTest):
             )
         )
         inPublic.publicArea.authPolicy = policyDigest
-        outsideInfo = TPM2B_DATA()
-        creationPCR = TPML_PCR_SELECTION()
 
-        priv, pub, _, _, _ = self.ectx.Create(
-            primary1, inSensitive, inPublic, outsideInfo, creationPCR
-        )
+        priv, pub, _, _, _ = self.ectx.Create(primary1, inSensitive, inPublic)
 
         childHandle = self.ectx.Load(primary1, priv, pub)
 

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -816,13 +816,13 @@ class TestEsys(TSS2_EsapiTest):
 
         self.ectx.ObjectChangeAuth(childHandle, parentHandle, "yetanotherone")
 
-        with self.assertEqual(TypeError):
+        with self.assertRaises(TypeError):
             self.ectx.ObjectChangeAuth("bad", parentHandle, "yetanotherone")
 
-        with self.assertEqual(TypeError):
+        with self.assertRaises(TypeError):
             self.ectx.ObjectChangeAuth(childHandle, 56.7, "yetanotherone")
 
-        with self.assertEqual(TypeError):
+        with self.assertRaises(TypeError):
             self.ectx.ObjectChangeAuth(childHandle, parentHandle, object())
 
     def test_createloaded(self):

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -1091,8 +1091,41 @@ class TestEsys(TSS2_EsapiTest):
         inQsB = TPM2B_ECC_POINT(outPublic.publicArea.unique.ecc)
         inQeB = Q
         Z1, Z2 = self.ectx.ZGen_2Phase(eccHandle, inQsB, inQeB, TPM2_ALG.ECDH, counter)
-        self.assertNotEqual(Z1, None)
-        self.assertNotEqual(Z2, None)
+        self.assertEqual(type(Z1), TPM2B_ECC_POINT)
+        self.assertEqual(type(Z2), TPM2B_ECC_POINT)
+
+        with self.assertRaises(TypeError):
+            self.ectx.ZGen_2Phase(42.5, inQsB, inQeB, TPM2_ALG.ECDH, counter)
+
+        with self.assertRaises(TypeError):
+            self.ectx.ZGen_2Phase(eccHandle, "hello", inQeB, TPM2_ALG.ECDH, counter)
+
+        with self.assertRaises(TypeError):
+            self.ectx.ZGen_2Phase(eccHandle, inQsB, object(), TPM2_ALG.ECDH, counter)
+
+        with self.assertRaises(TypeError):
+            self.ectx.ZGen_2Phase(eccHandle, inQsB, inQeB, object(), counter)
+
+        with self.assertRaises(TypeError):
+            self.ectx.ZGen_2Phase(eccHandle, inQsB, inQeB, TPM2_ALG.ECDH, "baz")
+
+        with self.assertRaises(ValueError):
+            self.ectx.ZGen_2Phase(eccHandle, inQsB, inQeB, TPM2_ALG.ECDH, 2 ** 18)
+
+        with self.assertRaises(TypeError):
+            self.ectx.ZGen_2Phase(
+                eccHandle, inQsB, inQeB, TPM2_ALG.ECDH, counter, session1=object()
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.ZGen_2Phase(
+                eccHandle, inQsB, inQeB, TPM2_ALG.ECDH, counter, session2="baz"
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.ZGen_2Phase(
+                eccHandle, inQsB, inQeB, TPM2_ALG.ECDH, counter, session3=45.5
+            )
 
     def test_EncryptDecrypt(self):
 

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -1221,6 +1221,57 @@ class TestEsys(TSS2_EsapiTest):
         self.assertEqual(bytes(inData), bytes(outData))
         self.assertEqual(bytes(outIV), bytes(outIV2))
 
+        ivIn = b"thisis16byteszxc"
+        inData = b"this is data to encrypt"
+        outCipherText, outIV = self.ectx.EncryptDecrypt2(
+            aesKeyHandle, False, TPM2_ALG.CFB, ivIn, inData
+        )
+
+        self.assertEqual(len(outIV), len(ivIn))
+
+        outData, outIV2 = self.ectx.EncryptDecrypt2(
+            aesKeyHandle, True, TPM2_ALG.CFB, ivIn, outCipherText
+        )
+        self.assertEqual(inData, bytes(outData))
+        self.assertEqual(bytes(outIV), bytes(outIV2))
+
+        with self.assertRaises(TypeError):
+            self.ectx.EncryptDecrypt(42.5, True, TPM2_ALG.CFB, ivIn, outCipherText)
+
+        with self.assertRaises(TypeError):
+            self.ectx.EncryptDecrypt(
+                aesKeyHandle, object(), TPM2_ALG.CFB, ivIn, outCipherText
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.EncryptDecrypt(aesKeyHandle, True, object(), ivIn, outCipherText)
+
+        with self.assertRaises(ValueError):
+            self.ectx.EncryptDecrypt(aesKeyHandle, True, 42, ivIn, outCipherText)
+
+        with self.assertRaises(TypeError):
+            self.ectx.EncryptDecrypt(
+                aesKeyHandle, True, TPM2_ALG.CFB, TPM2B_PUBLIC(), outCipherText
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.EncryptDecrypt(aesKeyHandle, True, TPM2_ALG.CFB, ivIn, None)
+
+        with self.assertRaises(TypeError):
+            self.ectx.EncryptDecrypt(
+                aesKeyHandle, True, TPM2_ALG.CFB, ivIn, outCipherText, session1=object()
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.EncryptDecrypt(
+                aesKeyHandle, True, TPM2_ALG.CFB, ivIn, outCipherText, session2="foo"
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.EncryptDecrypt(
+                aesKeyHandle, True, TPM2_ALG.CFB, ivIn, outCipherText, session3=12.3
+            )
+
     def test_Hash(self):
 
         # Null hierarchy default
@@ -1264,6 +1315,24 @@ class TestEsys(TSS2_EsapiTest):
             "03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4"
         )
         self.assertEqual(c, d)
+
+        with self.assertRaises(TypeError):
+            self.ectx.Hash(object(), TPM2_ALG.SHA256)
+
+        with self.assertRaises(TypeError):
+            self.ectx.Hash(inData, "baz")
+
+        with self.assertRaises(ValueError):
+            self.ectx.Hash(inData, 42)
+
+        with self.assertRaises(TypeError):
+            self.ectx.Hash(inData, TPM2_ALG.SHA256, session1=56.7)
+
+        with self.assertRaises(TypeError):
+            self.ectx.Hash(inData, TPM2_ALG.SHA256, session2="baz")
+
+        with self.assertRaises(TypeError):
+            self.ectx.Hash(inData, TPM2_ALG.SHA256, session3=object())
 
     def test_HMAC(self):
 

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -1574,6 +1574,33 @@ class TestEsys(TSS2_EsapiTest):
         )
         self.assertEqual(type(pcrs), TPML_DIGEST_VALUES)
 
+        with self.assertRaises(TypeError):
+            self.ectx.EventSequenceComplete(object(), seqHandle, None)
+
+        with self.assertRaises(ValueError):
+            self.ectx.EventSequenceComplete(42, seqHandle, None)
+
+        with self.assertRaises(TypeError):
+            self.ectx.EventSequenceComplete(ESYS_TR.PCR16, 46.5, None)
+
+        with self.assertRaises(TypeError):
+            self.ectx.EventSequenceComplete(ESYS_TR.PCR16, seqHandle, object())
+
+        with self.assertRaises(TypeError):
+            self.ectx.EventSequenceComplete(
+                ESYS_TR.PCR16, seqHandle, None, sequence1=67.34
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.EventSequenceComplete(
+                ESYS_TR.PCR16, seqHandle, None, sequence2="boo"
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.EventSequenceComplete(
+                ESYS_TR.PCR16, seqHandle, None, sequence3=object()
+            )
+
     def test_ContextSave_ContextLoad(self):
         inPublic = TPM2B_PUBLIC(
             TPMT_PUBLIC.parse(

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -1403,6 +1403,18 @@ class TestEsys(TSS2_EsapiTest):
         self.ectx.StirRandom("1234")
         self.ectx.StirRandom(TPM2B_SENSITIVE_DATA("1234"))
 
+        with self.assertRaises(TypeError):
+            self.ectx.StirRandom(object())
+
+        with self.assertRaises(TypeError):
+            self.ectx.StirRandom("1234", session1=56.7)
+
+        with self.assertRaises(TypeError):
+            self.ectx.StirRandom("1234", session2="foo")
+
+        with self.assertRaises(TypeError):
+            self.ectx.StirRandom("1234", session3=object())
+
     def test_HMAC_Sequence(self):
 
         inPublic = TPM2B_PUBLIC(

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -202,11 +202,17 @@ class TestEsys(TSS2_EsapiTest):
 
         self.ectx.IncrementalSelfTest(algs)
         toDo, rc = self.ectx.GetTestResult()
-        self.assertTrue(
-            isinstance(toDo, TPM2B_MAX_BUFFER),
-            f"Expected TODO list to be TPM2B_MAX_BUFFER, got: {type(toDo)}",
-        )
+        self.assertEqual(type(toDo), TPM2B_MAX_BUFFER)
         self.assertEqual(rc, TPM2_RC.SUCCESS)
+
+        with self.assertRaises(TypeError):
+            self.ectx.GetTestResult(session1=45.7)
+
+        with self.assertRaises(TypeError):
+            self.ectx.GetTestResult(session2=TPM2B_DATA())
+
+        with self.assertRaises(TypeError):
+            self.ectx.GetTestResult(session3=object())
 
     def test_hmac_session(self):
 

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -14,6 +14,18 @@ class TestEsys(TSS2_EsapiTest):
         r = self.ectx.GetRandom(5)
         self.assertEqual(len(r), 5)
 
+        with self.assertRaises(TypeError):
+            self.ectx.GetRandom("foo")
+
+        with self.assertRaises(TypeError):
+            self.ectx.GetRandom(5, session1="baz")
+
+        with self.assertRaises(TypeError):
+            self.ectx.GetRandom(5, session2=object())
+
+        with self.assertRaises(TypeError):
+            self.ectx.GetRandom(5, session3=56.7)
+
     def testCreatePrimary(self):
         inSensitive = TPM2B_SENSITIVE_CREATE()
         inPublic = TPM2B_PUBLIC()

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -620,6 +620,37 @@ class TestEsys(TSS2_EsapiTest):
         )
         self.assertEqual(bytes(certInfo), b"this is my credential")
 
+        with self.assertRaises(TypeError):
+            self.ectx.ActivateCredential(object(), childHandle, credentialBlob, secret)
+
+        with self.assertRaises(TypeError):
+            self.ectx.ActivateCredential(parentHandle, 76.4, credentialBlob, secret)
+
+        with self.assertRaises(TypeError):
+            self.ectx.ActivateCredential(
+                parentHandle, childHandle, TPM2B_PUBLIC(), secret
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.ActivateCredential(
+                parentHandle, childHandle, credentialBlob, object()
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.ActivateCredential(
+                parentHandle, childHandle, credentialBlob, secret, session1="foo"
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.ActivateCredential(
+                parentHandle, childHandle, credentialBlob, secret, session2=object()
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.ActivateCredential(
+                parentHandle, childHandle, credentialBlob, secret, session3=65.4
+            )
+
     def test_unseal(self):
 
         inSensitive = TPM2B_SENSITIVE_CREATE(

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -903,6 +903,50 @@ class TestEsys(TSS2_EsapiTest):
 
         self.assertEqual(bytes(message), bytes(message2))
 
+        outData = self.ectx.RSA_Encrypt(childHandle, "hello world", scheme)
+
+        message2 = self.ectx.RSA_Decrypt(childHandle, outData, scheme)
+
+        self.assertEqual(bytes(message), bytes(message2))
+
+        # negative test RSA_Encrypt
+        with self.assertRaises(TypeError):
+            self.ectx.RSA_Encrypt(45.6, message, scheme)
+
+        with self.assertRaises(TypeError):
+            self.ectx.RSA_Encrypt(childHandle, TPM2B_PUBLIC(), scheme)
+
+        with self.assertRaises(TypeError):
+            self.ectx.RSA_Encrypt(childHandle, message, "foo")
+
+        with self.assertRaises(TypeError):
+            self.ectx.RSA_Encrypt(childHandle, message, scheme, session1=object())
+
+        with self.assertRaises(TypeError):
+            self.ectx.RSA_Encrypt(childHandle, message, scheme, session2="foo")
+
+        with self.assertRaises(TypeError):
+            self.ectx.RSA_Encrypt(childHandle, message, scheme, session3=52.6)
+
+        # negative test RSA_Decrypt
+        with self.assertRaises(TypeError):
+            self.ectx.RSA_Decrypt(56.2, outData, scheme)
+
+        with self.assertRaises(TypeError):
+            self.ectx.RSA_Decrypt(childHandle, object(), scheme)
+
+        with self.assertRaises(TypeError):
+            self.ectx.RSA_Decrypt(childHandle, outData, TPM2_ALG.RSAES)
+
+        with self.assertRaises(TypeError):
+            self.ectx.RSA_Decrypt(childHandle, outData, scheme, session1=67.9)
+
+        with self.assertRaises(TypeError):
+            self.ectx.RSA_Decrypt(childHandle, outData, scheme, session2="foo")
+
+        with self.assertRaises(TypeError):
+            self.ectx.RSA_Decrypt(childHandle, outData, scheme, session3=object())
+
     def test_rsa_enc_dec_with_label(self):
 
         inSensitive = TPM2B_SENSITIVE_CREATE(

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -1539,6 +1539,21 @@ class TestEsys(TSS2_EsapiTest):
         with self.assertRaises(TypeError):
             self.ectx.HashSequenceStart(b"1234", TPM2_ALG.SHA256, session3=TPM2B_DATA())
 
+        with self.assertRaises(TypeError):
+            self.ectx.SequenceUpdate(56.7, "here is some data")
+
+        with self.assertRaises(TypeError):
+            self.ectx.SequenceUpdate(seqHandle, [])
+
+        with self.assertRaises(TypeError):
+            self.ectx.SequenceUpdate(seqHandle, "here is some data", sequence1="foo")
+
+        with self.assertRaises(TypeError):
+            self.ectx.SequenceUpdate(seqHandle, "here is some data", sequence2=object())
+
+        with self.assertRaises(TypeError):
+            self.ectx.SequenceUpdate(seqHandle, "here is some data", sequence3=78.23)
+
     def test_EventSequenceComplete(self):
 
         seqHandle = self.ectx.HashSequenceStart(TPM2B_AUTH(b"1234"), TPM2_ALG.NULL)

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -762,6 +762,18 @@ class TestEsys(TSS2_EsapiTest):
         secret = self.ectx.Unseal(childHandle)
         self.assertEqual(bytes(secret), b"sealedsecret")
 
+        with self.assertRaises(TypeError):
+            self.ectx.Unseal(45.2)
+
+        with self.assertRaises(TypeError):
+            self.ectx.Unseal(childHandle, session1=object())
+
+        with self.assertRaises(TypeError):
+            self.ectx.Unseal(childHandle, session2=67.4)
+
+        with self.assertRaises(TypeError):
+            self.ectx.Unseal(childHandle, session3="bar")
+
     def test_objectChangeAuth(self):
 
         inSensitive = TPM2B_SENSITIVE_CREATE(

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -816,6 +816,15 @@ class TestEsys(TSS2_EsapiTest):
 
         self.ectx.ObjectChangeAuth(childHandle, parentHandle, "yetanotherone")
 
+        with self.assertEqual(TypeError):
+            self.ectx.ObjectChangeAuth("bad", parentHandle, "yetanotherone")
+
+        with self.assertEqual(TypeError):
+            self.ectx.ObjectChangeAuth(childHandle, 56.7, "yetanotherone")
+
+        with self.assertEqual(TypeError):
+            self.ectx.ObjectChangeAuth(childHandle, parentHandle, object())
+
     def test_createloaded(self):
 
         inSensitive = TPM2B_SENSITIVE_CREATE(

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -1052,7 +1052,22 @@ class TestEsys(TSS2_EsapiTest):
     def test_ECC_Parameters(self):
 
         params = self.ectx.ECC_Parameters(TPM2_ECC_CURVE.NIST_P256)
-        self.assertNotEqual(params, None)
+        self.assertEqual(type(params), TPMS_ALGORITHM_DETAIL_ECC)
+
+        with self.assertRaises(ValueError):
+            self.ectx.ECC_Parameters(42)
+
+        with self.assertRaises(TypeError):
+            self.ectx.ECC_Parameters(TPM2B_DATA())
+
+        with self.assertRaises(TypeError):
+            self.ectx.ECC_Parameters(TPM2_ECC_CURVE.NIST_P256, session1="foo")
+
+        with self.assertRaises(TypeError):
+            self.ectx.ECC_Parameters(TPM2_ECC_CURVE.NIST_P256, session2=object())
+
+        with self.assertRaises(TypeError):
+            self.ectx.ECC_Parameters(TPM2_ECC_CURVE.NIST_P256, session3=TPM2B_DATA())
 
     def test_ZGen_2Phase(self):
 

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -1032,7 +1032,22 @@ class TestEsys(TSS2_EsapiTest):
         )
 
         outPoint = self.ectx.ECDH_ZGen(parentHandle, inPoint)
-        self.assertNotEqual(outPoint, None)
+        self.assertEqual(type(outPoint), TPM2B_ECC_POINT)
+
+        with self.assertRaises(TypeError):
+            self.ectx.ECDH_ZGen(object(), inPoint)
+
+        with self.assertRaises(TypeError):
+            self.ectx.ECDH_ZGen(parentHandle, "boo")
+
+        with self.assertRaises(TypeError):
+            self.ectx.ECDH_ZGen(parentHandle, inPoint, session1="baz")
+
+        with self.assertRaises(TypeError):
+            self.ectx.ECDH_ZGen(parentHandle, inPoint, session2=object())
+
+        with self.assertRaises(TypeError):
+            self.ectx.ECDH_ZGen(parentHandle, inPoint, session3=89.6)
 
     def test_ECC_Parameters(self):
 

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -1521,6 +1521,24 @@ class TestEsys(TSS2_EsapiTest):
         d = bytes(digest)
         self.assertEqual(e, d)
 
+        with self.assertRaises(TypeError):
+            self.ectx.HashSequenceStart(object(), TPM2_ALG.SHA256)
+
+        with self.assertRaises(TypeError):
+            self.ectx.HashSequenceStart(b"1234", "dssdf")
+
+        with self.assertRaises(ValueError):
+            self.ectx.HashSequenceStart(b"1234", 42)
+
+        with self.assertRaises(TypeError):
+            self.ectx.HashSequenceStart(b"1234", TPM2_ALG.SHA256, session1="baz")
+
+        with self.assertRaises(TypeError):
+            self.ectx.HashSequenceStart(b"1234", TPM2_ALG.SHA256, session2=56.7)
+
+        with self.assertRaises(TypeError):
+            self.ectx.HashSequenceStart(b"1234", TPM2_ALG.SHA256, session3=TPM2B_DATA())
+
     def test_EventSequenceComplete(self):
 
         seqHandle = self.ectx.HashSequenceStart(TPM2B_AUTH(b"1234"), TPM2_ALG.NULL)

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -2754,8 +2754,18 @@ class TestEsys(TSS2_EsapiTest):
 
         with self.assertRaises(TypeError):
             self.ectx.Quote(parentHandle, "sha256:1,2,3,4", qualifyingData=object())
+
         with self.assertRaises(TypeError):
             self.ectx.Quote(parentHandle, "sha256:1,2,3,4", inScheme=87)
+
+        with self.assertRaises(TypeError):
+            self.ectx.Quote(parentHandle, "sha256:1,2,3,4", session1="foo")
+
+        with self.assertRaises(TypeError):
+            self.ectx.Quote(parentHandle, "sha256:1,2,3,4", session2=25.68)
+
+        with self.assertRaises(TypeError):
+            self.ectx.Quote(parentHandle, "sha256:1,2,3,4", session3=object())
 
 
 if __name__ == "__main__":

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -2233,6 +2233,21 @@ class TestEsys(TSS2_EsapiTest):
                 primary1, encryptionKey, pub, duplicate, symSeed, TPM2B_PUBLIC()
             )
 
+        with self.assertRaises(TypeError):
+            self.ectx.Import(
+                primary1, encryptionKey, pub, duplicate, symSeed, sym, session1="boo"
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.Import(
+                primary1, encryptionKey, pub, duplicate, symSeed, sym, session2=object()
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.Import(
+                primary1, encryptionKey, pub, duplicate, symSeed, sym, session3=4.5
+            )
+
     def test_Quote(self):
 
         inPublic = TPM2B_PUBLIC(

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -181,6 +181,22 @@ class TestEsys(TSS2_EsapiTest):
 
         self.ectx.IncrementalSelfTest(algs)
 
+        self.ectx.IncrementalSelfTest("rsa,ecc,xor,aes,cbc")
+
+        with self.assertRaises(TypeError):
+            self.ectx.IncrementalSelfTest(None)
+        with self.assertRaises(TypeError):
+            self.ectx.IncrementalSelfTest(object())
+
+        with self.assertRaises(TypeError):
+            self.ectx.IncrementalSelfTest(session1=45.9)
+
+        with self.assertRaises(TypeError):
+            self.ectx.IncrementalSelfTest(session2=object())
+
+        with self.assertRaises(TypeError):
+            self.ectx.IncrementalSelfTest(session3=TPM2B_PUBLIC())
+
     def test_incremental_resume_test(self):
         algs = TPML_ALG.parse("rsa,ecc,xor,aes,cbc")
 

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -241,6 +241,52 @@ class TestEsys(TSS2_EsapiTest):
                 ESYS_TR.OWNER, "anotherpasswd", session1=hmac_session
             )
 
+        # test some bad params
+        with self.assertRaises(TypeError):
+            self.ectx.StartAuthSession(
+                object, ESYS_TR.NONE, None, TPM2_SE.HMAC, sym, TPM2_ALG.SHA256
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.StartAuthSession(
+                ESYS_TR.NONE, object(), None, TPM2_SE.HMAC, sym, TPM2_ALG.SHA256
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.StartAuthSession(
+                ESYS_TR.NONE,
+                ESYS_TR.NONE,
+                TPM2B_PUBLIC(),
+                TPM2_SE.HMAC,
+                sym,
+                TPM2_ALG.SHA256,
+            )
+
+        with self.assertRaises(ValueError):
+            self.ectx.StartAuthSession(
+                ESYS_TR.NONE, ESYS_TR.NONE, None, 8745635, sym, TPM2_ALG.SHA256
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.StartAuthSession(
+                ESYS_TR.NONE, ESYS_TR.NONE, None, object(), sym, TPM2_ALG.SHA256
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.StartAuthSession(
+                ESYS_TR.NONE, ESYS_TR.NONE, None, TPM2_SE.HMAC, 42, TPM2_ALG.SHA256
+            )
+
+        with self.assertRaises(ValueError):
+            self.ectx.StartAuthSession(
+                ESYS_TR.NONE, ESYS_TR.NONE, None, TPM2_SE.HMAC, sym, 8395847
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.StartAuthSession(
+                ESYS_TR.NONE, ESYS_TR.NONE, None, TPM2_SE.HMAC, sym, TPM2B_SYM_KEY()
+            )
+
     def test_start_authSession_enckey(self):
 
         inSensitive = TPM2B_SENSITIVE_CREATE()

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -2032,6 +2032,13 @@ class TestEsys(TSS2_EsapiTest):
         self.assertNotEqual(len(certifyInfo), 0)
         self.assertEqual(type(signature), TPMT_SIGNATURE)
 
+        certifyInfo, signature = self.ectx.Certify(
+            eccHandle, eccHandle, b"12345678", inScheme
+        )
+        self.assertEqual(type(certifyInfo), TPM2B_ATTEST)
+        self.assertNotEqual(len(certifyInfo), 0)
+        self.assertEqual(type(signature), TPMT_SIGNATURE)
+
         with self.assertRaises(TypeError):
             certifyInfo, signature = self.ectx.Certify(
                 TPM2B_ATTEST(), eccHandle, qualifyingData, inScheme
@@ -2050,6 +2057,21 @@ class TestEsys(TSS2_EsapiTest):
         with self.assertRaises(TypeError):
             certifyInfo, signature = self.ectx.Certify(
                 eccHandle, eccHandle, qualifyingData, TPM2B_PRIVATE()
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.Certify(
+                eccHandle, eccHandle, qualifyingData, inScheme, session1=56.7
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.Certify(
+                eccHandle, eccHandle, qualifyingData, inScheme, session2="foo"
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.Certify(
+                eccHandle, eccHandle, qualifyingData, inScheme, session3=object()
             )
 
     def test_CertifyCreation(self):

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -1554,6 +1554,27 @@ class TestEsys(TSS2_EsapiTest):
         with self.assertRaises(TypeError):
             self.ectx.SequenceUpdate(seqHandle, "here is some data", sequence3=78.23)
 
+        with self.assertRaises(TypeError):
+            self.ectx.SequenceComplete(78.25, "AnotherBuffer")
+
+        with self.assertRaises(TypeError):
+            self.ectx.SequenceComplete(seqHandle, [])
+
+        with self.assertRaises(TypeError):
+            self.ectx.SequenceComplete(seqHandle, "AnotherBuffer", hierarchy=object())
+
+        with self.assertRaises(ValueError):
+            self.ectx.SequenceComplete(seqHandle, "AnotherBuffer", hierarchy=42)
+
+        with self.assertRaises(TypeError):
+            self.ectx.SequenceComplete(seqHandle, "AnotherBuffer", session1=42.67)
+
+        with self.assertRaises(TypeError):
+            self.ectx.SequenceComplete(seqHandle, "AnotherBuffer", session2="baz")
+
+        with self.assertRaises(TypeError):
+            self.ectx.SequenceComplete(seqHandle, "AnotherBuffer", session3=object())
+
     def test_EventSequenceComplete(self):
 
         seqHandle = self.ectx.HashSequenceStart(TPM2B_AUTH(b"1234"), TPM2_ALG.NULL)

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -993,6 +993,18 @@ class TestEsys(TSS2_EsapiTest):
         self.assertNotEqual(zPoint, None)
         self.assertNotEqual(pubPoint, None)
 
+        with self.assertRaises(TypeError):
+            self.ectx.ECDH_KeyGen(56.8)
+
+        with self.assertRaises(TypeError):
+            self.ectx.ECDH_KeyGen(parentHandle, session1="baz")
+
+        with self.assertRaises(TypeError):
+            self.ectx.ECDH_KeyGen(parentHandle, session2=object())
+
+        with self.assertRaises(TypeError):
+            self.ectx.ECDH_KeyGen(parentHandle, session3=45.6)
+
     def test_ECDH_ZGen(self):
 
         alg = "ecc256:ecdh"

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -1067,7 +1067,7 @@ class TestEsys(TSS2_EsapiTest):
         inPublic = TPM2B_PUBLIC(TPMT_PUBLIC.parse(alg=alg, objectAttributes=attrs))
         inSensitive = TPM2B_SENSITIVE_CREATE(TPMS_SENSITIVE_CREATE())
 
-        eccHandle, outPublic, _, _, _ = self.ectx.CreatePrimary(inSensitive, inPublic,)
+        eccHandle, outPublic, _, _, _ = self.ectx.CreatePrimary(inSensitive, inPublic)
 
         curveId = TPM2_ECC.NIST_P256
 

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -847,8 +847,31 @@ class TestEsys(TSS2_EsapiTest):
             parentHandle, childInSensitive, childInPublic
         )
         self.assertNotEqual(childHandle, 0)
-        self.assertNotEqual(priv, None)
-        self.assertNotEqual(pub, None)
+        self.assertEqual(type(priv), TPM2B_PRIVATE)
+        self.assertEqual(type(pub), TPM2B_PUBLIC)
+
+        childHandle, priv, pub = self.ectx.CreateLoaded(parentHandle, childInSensitive)
+        self.assertNotEqual(childHandle, 0)
+        self.assertEqual(type(priv), TPM2B_PRIVATE)
+        self.assertEqual(type(pub), TPM2B_PUBLIC)
+
+        with self.assertRaises(TypeError):
+            self.ectx.CreateLoaded(65.4, childInSensitive, childInPublic)
+
+        with self.assertRaises(TypeError):
+            self.ectx.CreateLoaded(parentHandle, "1223", childInPublic)
+
+        with self.assertRaises(TypeError):
+            self.ectx.CreateLoaded(parentHandle, childInSensitive, object())
+
+        with self.assertRaises(TypeError):
+            self.ectx.CreateLoaded(parentHandle, childInSensitive, session1=56.7)
+
+        with self.assertRaises(TypeError):
+            self.ectx.CreateLoaded(parentHandle, childInSensitive, session2=b"baz")
+
+        with self.assertRaises(TypeError):
+            self.ectx.CreateLoaded(parentHandle, childInSensitive, session3=object())
 
     def test_rsa_enc_dec(self):
 

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -518,6 +518,15 @@ class TestEsys(TSS2_EsapiTest):
         childHandle = self.ectx.Load(parentHandle, priv, pub)
         self.assertTrue(childHandle)
 
+        with self.assertRaises(TypeError):
+            self.ectx.Load(42.5, priv, pub)
+
+        with self.assertRaises(TypeError):
+            self.ectx.Load(parentHandle, TPM2B_DATA(), pub)
+
+        with self.assertRaises(TypeError):
+            self.ectx.Load(parentHandle, priv, object())
+
     def test_readpublic(self):
 
         inSensitive = TPM2B_SENSITIVE_CREATE(

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -1463,6 +1463,27 @@ class TestEsys(TSS2_EsapiTest):
 
         self.assertEqual(len(digest), 32)
 
+        with self.assertRaises(TypeError):
+            self.ectx.HMAC_Start(45.6, "1234", TPM2_ALG.SHA256)
+
+        with self.assertRaises(TypeError):
+            self.ectx.HMAC_Start(handle, dict(), TPM2_ALG.SHA256)
+
+        with self.assertRaises(TypeError):
+            self.ectx.HMAC_Start(handle, "1234", object())
+
+        with self.assertRaises(ValueError):
+            self.ectx.HMAC_Start(handle, "1234", 42)
+
+        with self.assertRaises(TypeError):
+            self.ectx.HMAC_Start(handle, "1234", TPM2_ALG.SHA256, session1="baz")
+
+        with self.assertRaises(TypeError):
+            self.ectx.HMAC_Start(handle, "1234", TPM2_ALG.SHA256, session2=object())
+
+        with self.assertRaises(TypeError):
+            self.ectx.HMAC_Start(handle, "1234", TPM2_ALG.SHA256, session3=45.6)
+
     def test_HashSequence(self):
 
         seqHandle = self.ectx.HashSequenceStart(None, TPM2_ALG.SHA256)

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -1211,6 +1211,23 @@ class TypesTest(unittest.TestCase):
     def test_TPM_FRIENDLY_INT_contains(self):
         self.assertTrue(TPM2_CC.contains(TPM2_CC.AC_Send))
 
+    def test_TPM2B_PUBLIC_parse(self):
+
+        tpm2b = TPM2B_PUBLIC.parse("rsa")
+        templ = tpm2b.publicArea
+        self.assertEqual(templ.nameAlg, TPM2_ALG.SHA256)
+        self.assertEqual(
+            templ.objectAttributes, TPMA_OBJECT.DEFAULT_TPM2_TOOLS_CREATE_ATTRS
+        )
+
+        self.assertEqual(templ.type, TPM2_ALG.RSA)
+
+        self.assertEqual(templ.type, TPM2_ALG.RSA)
+        self.assertEqual(templ.parameters.rsaDetail.keyBits, 2048)
+        self.assertEqual(templ.parameters.asymDetail.scheme.scheme, TPM2_ALG.NULL)
+
+        self.assertEqual(templ.parameters.rsaDetail.symmetric.algorithm, TPM2_ALG.NULL)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -242,13 +242,25 @@ class ESAPI:
         self,
         parentHandle,
         inSensitive,
-        inPublic,
-        outsideInfo,
-        creationPCR,
+        inPublic="rsa2048",
+        outsideInfo=TPM2B_DATA(),
+        creationPCR=TPML_PCR_SELECTION(),
         session1=ESYS_TR.PASSWORD,
         session2=ESYS_TR.NONE,
         session3=ESYS_TR.NONE,
     ):
+
+        check_handle_type(parentHandle, "parentHandle")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
+        inPublic_cdata = get_cdata(inPublic, TPM2B_PUBLIC, "inPublic")
+        inSensitive_cdata = get_cdata(
+            inSensitive, TPM2B_SENSITIVE_CREATE, "inSensitive"
+        )
+        outsideInfo_cdata = get_cdata(outsideInfo, TPM2B_DATA, "outsideInfo")
+        creationPCR_cdata = get_cdata(creationPCR, TPML_PCR_SELECTION, "creationPCR")
 
         outPrivate = ffi.new("TPM2B_PRIVATE **")
         outPublic = ffi.new("TPM2B_PUBLIC **")
@@ -262,10 +274,10 @@ class ESAPI:
                 session1,
                 session2,
                 session3,
-                inSensitive._cdata,
-                inPublic._cdata,
-                outsideInfo._cdata,
-                creationPCR._cdata,
+                inSensitive_cdata,
+                inPublic_cdata,
+                outsideInfo_cdata,
+                creationPCR_cdata,
                 outPrivate,
                 outPublic,
                 creationData,

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -1113,6 +1113,15 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
+        if not isinstance(bytesRequested, int):
+            raise TypeError(
+                f"Expected bytesRequested type to be int, got {type(bytesRequested)}"
+            )
+
         randomBytes = ffi.new("TPM2B_DIGEST **")
         _chkrc(
             lib.Esys_GetRandom(

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -1197,10 +1197,16 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
-        if isinstance(auth, (str, bytes)):
-            auth = TPM2B_AUTH(auth)
-        elif auth is None:
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
+        check_friendly_int(hashAlg, "hashAlg", TPM2_ALG)
+
+        if auth is None:
             auth = TPM2B_AUTH()
+
+        auth_cdata = get_cdata(auth, TPM2B_AUTH, "auth")
 
         sequenceHandle = ffi.new("ESYS_TR *")
         _chkrc(
@@ -1209,7 +1215,7 @@ class ESAPI:
                 session1,
                 session2,
                 session3,
-                auth._cdata,
+                auth_cdata,
                 hashAlg,
                 sequenceHandle,
             )

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -400,6 +400,11 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
+        check_handle_type(objectHandle, "objectHandle")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
         outPublic = ffi.new("TPM2B_PUBLIC **")
         name = ffi.new("TPM2B_NAME **")
         qualifiedName = ffi.new("TPM2B_NAME **")

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -1081,8 +1081,14 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
-        if isinstance(buffer, (bytes, str)):
-            buffer = TPM2B_MAX_BUFFER(buffer)
+        check_handle_type(handle, "handle")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
+        check_friendly_int(hashAlg, "hashAlg", TPM2_ALG)
+
+        buffer_cdata = get_cdata(buffer, TPM2B_MAX_BUFFER, "buffer")
 
         outHMAC = ffi.new("TPM2B_DIGEST **")
         _chkrc(
@@ -1092,7 +1098,7 @@ class ESAPI:
                 session1,
                 session2,
                 session3,
-                buffer._cdata,
+                buffer_cdata,
                 hashAlg,
                 outHMAC,
             )

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -1003,6 +1003,20 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
+        check_handle_type(keyHandle, "keyHandle")
+
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
+        check_friendly_int(mode, "mode", TPM2_ALG)
+
+        ivIn_cdata = get_cdata(ivIn, TPM2B_IV, "ivIn")
+        inData_cdata = get_cdata(inData, TPM2B_MAX_BUFFER, "inData")
+
+        if not isinstance(decrypt, bool):
+            raise TypeError("Expected decrypt to be type bool, got {type(decrypt)}")
+
         outData = ffi.new("TPM2B_MAX_BUFFER **")
         ivOut = ffi.new("TPM2B_IV **")
         _chkrc(
@@ -1012,10 +1026,10 @@ class ESAPI:
                 session1,
                 session2,
                 session3,
-                inData._cdata,
+                inData_cdata,
                 decrypt,
                 mode,
-                ivIn._cdata,
+                ivIn_cdata,
                 outData,
                 ivOut,
             )
@@ -1032,8 +1046,13 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
-        if isinstance(data, (bytes, str)):
-            data = TPM2B_MAX_BUFFER(data)
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
+        check_friendly_int(hashAlg, "hashAlg", TPM2_ALG)
+
+        data_cdata = get_cdata(data, TPM2B_MAX_BUFFER, "data")
 
         outHash = ffi.new("TPM2B_DIGEST **")
         validation = ffi.new("TPMT_TK_HASHCHECK **")
@@ -1043,7 +1062,7 @@ class ESAPI:
                 session1,
                 session2,
                 session3,
-                data._cdata,
+                data_cdata,
                 hashAlg,
                 hierarchy,
                 outHash,

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -155,10 +155,16 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
+        toTest_cdata = get_cdata(toTest, TPML_ALG, "toTest")
+
         toDoList = ffi.new("TPML_ALG **")
         _chkrc(
             lib.Esys_IncrementalSelfTest(
-                self.ctx, session1, session2, session3, toTest._cdata, toDoList
+                self.ctx, session1, session2, session3, toTest_cdata, toDoList
             )
         )
         return TPML_ALG(get_ptr(toDoList))

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -1260,6 +1260,8 @@ class ESAPI:
         check_handle_type(session2, "session2")
         check_handle_type(session3, "session3")
 
+        check_friendly_int(hierarchy, "hierarchy", ESYS_TR)
+
         buffer_cdata = get_cdata(buffer, TPM2B_MAX_BUFFER, "buffer", allow_none=True)
 
         result = ffi.new("TPM2B_DIGEST **")

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -1442,16 +1442,17 @@ class ESAPI:
 
     def GetSessionAuditDigest(
         self,
-        privacyAdminHandle,
         signHandle,
         sessionHandle,
         qualifyingData,
-        inScheme,
+        inScheme=TPMT_SIG_SCHEME(scheme=TPM2_ALG.NULL),
+        privacyAdminHandle=ESYS_TR.RH_ENDORSEMENT,
         session1=ESYS_TR.PASSWORD,
         session2=ESYS_TR.PASSWORD,
         session3=ESYS_TR.NONE,
     ):
 
+        check_handle_type(sessionHandle, "sessionHandle")
         check_handle_type(privacyAdminHandle, "privacyAdminHandle")
         check_handle_type(signHandle, "signHandle")
         check_handle_type(session1, "session1")

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -31,9 +31,12 @@ def get_cdata(value, expected, varname, allow_none=False):
         return value
 
     vname = type(value).__name__
+    parse_method = getattr(expected, "parse", None)
     if isinstance(value, (bytes, str)) and issubclass(expected, TPM2B_SIMPLE_OBJECT):
         bo = expected(value)
         return bo._cdata
+    elif isinstance(value, str) and parse_method and callable(parse_method):
+        return expected.parse(value)._cdata
     elif not isinstance(value, expected):
         raise TypeError(f"expected {varname} to be {tname}, got {vname}")
 
@@ -1181,9 +1184,9 @@ class ESAPI:
     def Quote(
         self,
         signHandle,
-        qualifyingData,
-        inScheme,
         PCRselect,
+        qualifyingData,
+        inScheme=TPMT_SIG_SCHEME(scheme=TPM2_ALG.NULL),
         session1=ESYS_TR.PASSWORD,
         session2=ESYS_TR.NONE,
         session3=ESYS_TR.NONE,
@@ -1195,9 +1198,11 @@ class ESAPI:
         check_handle_type(session3, "session3")
 
         qualifyingData_cdata = get_cdata(
-            qualifyingData, TPM2B_DATA, "qualifyingData", allow_none=True
+            qualifyingData, TPM2B_DATA, "qualifyingData"
         )
+
         inScheme_cdata = get_cdata(inScheme, TPMT_SIG_SCHEME, "inScheme")
+
         PCRselect_cdata = get_cdata(PCRselect, TPML_PCR_SELECTION, "PCRselect")
 
         quoted = ffi.new("TPM2B_ATTEST **")

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -829,6 +829,11 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
+        check_handle_type(keyHandle, "keyHandle")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
         zPoint = ffi.new("TPM2B_ECC_POINT **")
         pubPoint = ffi.new("TPM2B_ECC_POINT **")
         _chkrc(

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -234,6 +234,16 @@ class ESAPI:
 
     def TRSess_SetAttributes(self, session, attributes, mask=0xFF):
 
+        check_handle_type(session, "session")
+
+        if not isinstance(attributes, int):
+            raise TypeError(
+                f"Expected attributes to be type int, got {type(attributes)}"
+            )
+
+        if not isinstance(mask, int):
+            raise TypeError(f"Expected mask to be type int, got {type(attributes)}")
+
         _chkrc(lib.Esys_TRSess_SetAttributes(self.ctx, session, attributes, mask))
 
     def PolicyRestart(

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -562,11 +562,25 @@ class ESAPI:
         self,
         parentHandle,
         inSensitive,
-        inPublic,
+        inPublic="rsa2048",
         session1=ESYS_TR.PASSWORD,
         session2=ESYS_TR.NONE,
         session3=ESYS_TR.NONE,
     ):
+
+        check_handle_type(parentHandle, "parentHandle")
+
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
+        if isinstance(inPublic, str):
+            inPublic = TPM2B_TEMPLATE(TPMT_PUBLIC.parse(inPublic).Marshal())
+
+        inSensitive_cdata = get_cdata(
+            inSensitive, TPM2B_SENSITIVE_CREATE, "inSensitive"
+        )
+        inPublic_cdata = get_cdata(inPublic, TPM2B_TEMPLATE, "inPublic")
 
         objectHandle = ffi.new("ESYS_TR *")
         outPrivate = ffi.new("TPM2B_PRIVATE **")
@@ -578,8 +592,8 @@ class ESAPI:
                 session1,
                 session2,
                 session3,
-                inSensitive._cdata,
-                inPublic._cdata,
+                inSensitive_cdata,
+                inPublic_cdata,
                 objectHandle,
                 outPrivate,
                 outPublic,

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -475,6 +475,15 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
+        check_handle_type(handle, "handle")
+
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
+        credential_cdata = get_cdata(credential, TPM2B_DIGEST, "credential")
+        objectName_cdata = get_cdata(objectName, TPM2B_NAME, "objectName")
+
         credentialBlob = ffi.new("TPM2B_ID_OBJECT **")
         secret = ffi.new("TPM2B_ENCRYPTED_SECRET **")
         _chkrc(
@@ -484,8 +493,8 @@ class ESAPI:
                 session1,
                 session2,
                 session3,
-                credential._cdata,
-                objectName._cdata,
+                credential_cdata,
+                objectName_cdata,
                 credentialBlob,
                 secret,
             )

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -199,12 +199,19 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
-        if nonceCaller is None:
-            nonceCaller = ffi.NULL
-        elif isinstance(nonceCaller, TPM2B_NONCE):
-            nonceCaller = nonceCaller._cdata
-        else:
-            raise TypeError("Expected nonceCaller to be None or TPM2B_NONCE")
+        check_handle_type(tpmKey, "tpmKey")
+        check_handle_type(bind, "bind")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
+        check_friendly_int(sessionType, "sessionType", TPM2_SE)
+        check_friendly_int(authHash, "authHash", TPM2_ALG)
+
+        nonceCaller_cdata = get_cdata(
+            nonceCaller, TPM2B_NONCE, "nonceCaller", allow_none=True
+        )
+        symmetric_cdata = get_cdata(symmetric, TPMT_SYM_DEF, "symmetric")
 
         sessionHandle = ffi.new("ESYS_TR *")
         _chkrc(
@@ -215,9 +222,9 @@ class ESAPI:
                 session1,
                 session2,
                 session3,
-                nonceCaller,
+                nonceCaller_cdata,
                 sessionType,
-                symmetric._cdata,
+                symmetric_cdata,
                 authHash,
                 sessionHandle,
             )

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -512,6 +512,12 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
+        check_handle_type(itemHandle, "itemHandle")
+
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
         outData = ffi.new("TPM2B_SENSITIVE_DATA **")
         _chkrc(
             lib.Esys_Unseal(self.ctx, itemHandle, session1, session2, session3, outData)

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -330,6 +330,14 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
+        check_handle_type(parentHandle, "parentHandle")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
+        inPublic_cdata = get_cdata(inPublic, TPM2B_PUBLIC, "inPublic")
+        inPrivate_cdata = get_cdata(inPrivate, TPM2B_PRIVATE, "inPrivate")
+
         objectHandle = ffi.new("ESYS_TR *")
         _chkrc(
             lib.Esys_Load(
@@ -338,8 +346,8 @@ class ESAPI:
                 session1,
                 session2,
                 session3,
-                inPrivate._cdata,
-                inPublic._cdata,
+                inPrivate_cdata,
+                inPublic_cdata,
                 objectHandle,
             )
         )

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -1232,14 +1232,16 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
-        if isinstance(buffer, (str, bytes)):
-            buffer = TPM2B_MAX_BUFFER(buffer)
-        elif buffer is None:
-            buffer = TPM2B_MAX_BUFFER()
+        check_handle_type(sequenceHandle, "sequenceHandle")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
+        buffer_cdata = get_cdata(buffer, TPM2B_MAX_BUFFER, "buffer", allow_none=True)
 
         _chkrc(
             lib.Esys_SequenceUpdate(
-                self.ctx, sequenceHandle, session1, session2, session3, buffer._cdata
+                self.ctx, sequenceHandle, session1, session2, session3, buffer_cdata
             )
         )
 

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -1290,10 +1290,14 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
-        if isinstance(buffer, (str, bytes)):
-            buffer = TPM2B_MAX_BUFFER(buffer)
-        elif buffer is None:
-            buffer = TPM2B_MAX_BUFFER()
+        check_handle_type(sequenceHandle, "sequenceHandle")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
+        check_friendly_int(pcrHandle, "pcrHandle", ESYS_TR)
+
+        buffer_cdata = get_cdata(buffer, TPM2B_MAX_BUFFER, "buffer", allow_none=True)
 
         results = ffi.new("TPML_DIGEST_VALUES **")
         _chkrc(
@@ -1304,7 +1308,7 @@ class ESAPI:
                 session1,
                 session2,
                 session3,
-                buffer._cdata,
+                buffer_cdata,
                 results,
             )
         )

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -1139,11 +1139,14 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
-        if isinstance(inData, (bytes, str)):
-            inData = TPM2B_SENSITIVE_DATA(inData)
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
+        inData_cdata = get_cdata(inData, TPM2B_SENSITIVE_DATA, "inData")
 
         _chkrc(
-            lib.Esys_StirRandom(self.ctx, session1, session2, session3, inData._cdata)
+            lib.Esys_StirRandom(self.ctx, session1, session2, session3, inData_cdata)
         )
 
     def HMAC_Start(

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -907,6 +907,25 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
+        check_handle_type(session1, "keyA")
+
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
+        check_friendly_int(inScheme, "inScheme", TPM2_ALG)
+
+        if not isinstance(counter, int):
+            raise TypeError(f"Expected counter to be type int, got {type(counter)}")
+
+        if counter < 0 or counter > 65535:
+            raise ValueError(
+                f"Expected counter to be in range of uint16_t, got {counter}"
+            )
+
+        inQsB_cdata = get_cdata(inQsB, TPM2B_ECC_POINT, "inQsB")
+        inQeB_cdata = get_cdata(inQeB, TPM2B_ECC_POINT, "inQeB")
+
         outZ1 = ffi.new("TPM2B_ECC_POINT **")
         outZ2 = ffi.new("TPM2B_ECC_POINT **")
         _chkrc(
@@ -916,8 +935,8 @@ class ESAPI:
                 session1,
                 session2,
                 session3,
-                inQsB._cdata,
-                inQeB._cdata,
+                inQsB_cdata,
+                inQeB_cdata,
                 inScheme,
                 counter,
                 outZ1,

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -358,15 +358,24 @@ class ESAPI:
         self,
         inPrivate,
         inPublic,
-        hierarchy,
+        hierarchy=ESYS_TR.NULL,
         session1=ESYS_TR.NONE,
         session2=ESYS_TR.NONE,
         session3=ESYS_TR.NONE,
     ):
+
+        check_friendly_int(hierarchy, "hierarchy", ESYS_TR)
+
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
         inPrivate_cdata = get_cdata(
             inPrivate, TPM2B_SENSITIVE, "inPrivate", allow_none=True
         )
+
         inPublic_cdata = get_cdata(inPublic, TPM2B_PUBLIC, "inPublic")
+
         objectHandle = ffi.new("ESYS_TR *")
         _chkrc(
             lib.Esys_LoadExternal(

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -173,6 +173,10 @@ class ESAPI:
         self, session1=ESYS_TR.NONE, session2=ESYS_TR.NONE, session3=ESYS_TR.NONE
     ):
 
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
         outData = ffi.new("TPM2B_MAX_BUFFER **")
         testResult = ffi.new("TPM2_RC *")
         _chkrc(

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -958,6 +958,20 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
+        check_handle_type(keyHandle, "keyHandle")
+
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
+        check_friendly_int(mode, "mode", TPM2_ALG)
+
+        ivIn_cdata = get_cdata(ivIn, TPM2B_IV, "ivIn")
+        inData_cdata = get_cdata(inData, TPM2B_MAX_BUFFER, "inData")
+
+        if not isinstance(decrypt, bool):
+            raise TypeError("Expected decrypt to be type bool, got {type(decrypt)}")
+
         outData = ffi.new("TPM2B_MAX_BUFFER **")
         ivOut = ffi.new("TPM2B_IV **")
         _chkrc(
@@ -969,8 +983,8 @@ class ESAPI:
                 session3,
                 decrypt,
                 mode,
-                ivIn._cdata,
-                inData._cdata,
+                ivIn_cdata,
+                inData_cdata,
                 outData,
                 ivOut,
             )

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -852,6 +852,13 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
+        check_handle_type(keyHandle, "keyHandle")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
+        inPoint_cdata = get_cdata(inPoint, TPM2B_ECC_POINT, "inPoint")
+
         outPoint = ffi.new("TPM2B_ECC_POINT **")
         _chkrc(
             lib.Esys_ECDH_ZGen(
@@ -860,7 +867,7 @@ class ESAPI:
                 session1,
                 session2,
                 session3,
-                inPoint._cdata,
+                inPoint_cdata,
                 outPoint,
             )
         )

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -437,6 +437,18 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
+        check_handle_type(activateHandle, "activateHandle")
+        check_handle_type(keyHandle, "keyHandle")
+
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
+        credentialBlob_cdata = get_cdata(
+            credentialBlob, TPM2B_ID_OBJECT, "credentialBlob"
+        )
+        secret_cdata = get_cdata(secret, TPM2B_ENCRYPTED_SECRET, "secret")
+
         certInfo = ffi.new("TPM2B_DIGEST **")
         _chkrc(
             lib.Esys_ActivateCredential(
@@ -446,8 +458,8 @@ class ESAPI:
                 session1,
                 session2,
                 session3,
-                credentialBlob._cdata,
-                secret._cdata,
+                credentialBlob_cdata,
+                secret_cdata,
                 certInfo,
             )
         )

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -881,6 +881,12 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
+        check_friendly_int(curveID, "curveID", TPM2_ECC_CURVE)
+
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
         parameters = ffi.new("TPMS_ALGORITHM_DETAIL_ECC **")
         _chkrc(
             lib.Esys_ECC_Parameters(

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -533,8 +533,15 @@ class ESAPI:
         session2=ESYS_TR.NONE,
         session3=ESYS_TR.NONE,
     ):
-        if isinstance(newAuth, (str, bytes)):
-            newAuth = TPM2B_AUTH(newAuth)
+
+        check_handle_type(objectHandle, "objectHandle")
+        check_handle_type(parentHandle, "parentHandle")
+
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
+        newAuth_cdata = get_cdata(newAuth, TPM2B_AUTH, "newAuth")
 
         outPrivate = ffi.new("TPM2B_PRIVATE **")
         _chkrc(
@@ -545,7 +552,7 @@ class ESAPI:
                 session1,
                 session2,
                 session3,
-                newAuth._cdata,
+                newAuth_cdata,
                 outPrivate,
             )
         )

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -1159,10 +1159,18 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
-        if isinstance(auth, (str, bytes)):
-            auth = TPM2B_AUTH(auth)
-        elif auth is None:
+        check_handle_type(handle, "handle")
+
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
+        check_friendly_int(hashAlg, "hashAlg", TPM2_ALG)
+
+        if auth is None:
             auth = TPM2B_AUTH()
+
+        auth_cdata = get_cdata(auth, TPM2B_AUTH, "auth")
 
         sequenceHandle = ffi.new("ESYS_TR *")
         _chkrc(
@@ -1172,7 +1180,7 @@ class ESAPI:
                 session1,
                 session2,
                 session3,
-                auth._cdata,
+                auth_cdata,
                 hashAlg,
                 sequenceHandle,
             )

--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -11,6 +11,7 @@ from tpm2_pytss.utils import (
     cpointer_to_ctype,
     fixup_classname,
     convert_to_python_native,
+    mock_bail,
 )
 from tpm2_pytss.crypto import (
     public_from_encoding,
@@ -862,6 +863,12 @@ class TPMA_MEMORY(TPM_FRIENDLY_INT):
 
 class TPM_OBJECT(object):
     def __init__(self, _cdata=None, **kwargs):
+
+        # Rather than trying to mock the FFI interface, just avoid it and return
+        # the base object. This is really only needed for documentation, and it
+        # makes it work. Why Yes, this is a terrible hack (cough cough).
+        if mock_bail():
+            return
 
         _cdata, kwargs = fixup_cdata_kwargs(self, _cdata, kwargs)
         object.__setattr__(self, "_cdata", _cdata)

--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -1710,6 +1710,16 @@ class TPM2B_PUBLIC(TPM_OBJECT):
     def getName(self):
         return self.publicArea.getName()
 
+    @classmethod
+    def parse(
+        cls,
+        alg="rsa",
+        objectAttributes=TPMA_OBJECT.DEFAULT_TPM2_TOOLS_CREATE_ATTRS,
+        nameAlg="sha256",
+    ):
+
+        return cls(TPMT_PUBLIC.parse(alg, objectAttributes, nameAlg))
+
 
 class TPM2B_PUBLIC_KEY_RSA(TPM2B_SIMPLE_OBJECT):
     pass

--- a/tpm2_pytss/utils.py
+++ b/tpm2_pytss/utils.py
@@ -2,8 +2,13 @@
 SPDX-License-Identifier: BSD-2
 """
 
+import sys
+
 from ._libtpm2_pytss import ffi
 from .TSS2_Exception import TSS2_Exception
+
+# Peek into the loaded modules, if mock is loaded, set __MOCK__ to True, else False
+__MOCK__ = "unittest.mock" in sys.modules
 
 
 def _chkrc(rc):
@@ -157,3 +162,7 @@ def fixup_classname(tipe):
         return tipe.cname[len(tipe.kind) + 1 :]
 
     return tipe.cname
+
+
+def mock_bail():
+    return __MOCK__


### PR DESCRIPTION
ESAPI: update CreatePrimary API

Make CreatePrimary interface:
  - not need PCR data, default empty
  - not need creation data, default empty
    - creation data since it's a pcr selection supports pcr selection
      strings.
  - not need hierarchy, default owner
  - support tpm2-tools like initializer strings for TPM2B_PUBLIC
    - Defualt name alg SHA256
    - Default attribute set

It will stillr require the sensitive portion so folks have to explicitly
opt in to no passwords.

Additional Notes:
I did initially code this in a way where the get_cdata, on getting passed a string, if the current class object didn't have a parse routine, would look at the subfields and if only one subfield other than size existed, instantiate that, get the cdata and then use than call that subclass's parse method. While more generic, it was a little more code, more complex to read, and the current usecase is only for TPM2B_PUBLIC. Thus, writing generic code for a one off case seemed more complicated than it needed to be. So I ended up just adding parse to TPM2B_PUBLIC.


