### PR TITLE
crypto.py: add support for pure DER encoded private keys

### DIFF
--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -140,7 +140,7 @@ class CryptoTest(TSS2_EsapiTest):
 
     def test_private_from_pem_rsa(self):
         priv = types.TPM2B_SENSITIVE()
-        crypto.private_from_encoding(rsa_private_key, priv)
+        crypto.private_from_encoding(rsa_private_key, priv.sensitiveArea)
 
         self.assertEqual(priv.sensitiveArea.sensitiveType, types.TPM2_ALG.RSA)
         self.assertEqual(
@@ -206,7 +206,7 @@ class CryptoTest(TSS2_EsapiTest):
 
     def test_private_from_pem_ecc(self):
         priv = types.TPM2B_SENSITIVE()
-        crypto.private_from_encoding(ecc_private_key, priv)
+        crypto.private_from_encoding(ecc_private_key, priv.sensitiveArea)
 
         self.assertEqual(priv.sensitiveArea.sensitiveType, types.TPM2_ALG.ECC)
         self.assertEqual(
@@ -340,7 +340,7 @@ class CryptoTest(TSS2_EsapiTest):
         der = b64decode(b64)
 
         sens = TPM2B_SENSITIVE()
-        crypto.private_from_encoding(der, sens)
+        crypto.private_from_encoding(der, sens.sensitiveArea)
 
     def test_private_from_pem_ecc_der(self):
         sl = ecc_private_key.strip().splitlines()
@@ -348,7 +348,7 @@ class CryptoTest(TSS2_EsapiTest):
         der = b64decode(b64)
 
         sens = TPM2B_SENSITIVE()
-        crypto.private_from_encoding(der, sens)
+        crypto.private_from_encoding(der, sens.sensitiveArea)
 
     def test_private_from_pem_bad_der(self):
         der = b"" * 1024

--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -140,7 +140,7 @@ class CryptoTest(TSS2_EsapiTest):
 
     def test_private_from_pem_rsa(self):
         priv = types.TPM2B_SENSITIVE()
-        crypto.private_from_pem(rsa_private_key, priv)
+        crypto.private_from_encoding(rsa_private_key, priv)
 
         self.assertEqual(priv.sensitiveArea.sensitiveType, types.TPM2_ALG.RSA)
         self.assertEqual(
@@ -206,7 +206,7 @@ class CryptoTest(TSS2_EsapiTest):
 
     def test_private_from_pem_ecc(self):
         priv = types.TPM2B_SENSITIVE()
-        crypto.private_from_pem(ecc_private_key, priv)
+        crypto.private_from_encoding(ecc_private_key, priv)
 
         self.assertEqual(priv.sensitiveArea.sensitiveType, types.TPM2_ALG.ECC)
         self.assertEqual(
@@ -332,4 +332,27 @@ class CryptoTest(TSS2_EsapiTest):
         pub = TPMT_PUBLIC()
         with self.assertRaises(ValueError) as e:
             crypto.public_from_encoding(der, pub)
+        self.assertEqual(str(e.exception), "Unsupported key format")
+
+    def test_private_from_pem_rsa_der(self):
+        sl = rsa_private_key.strip().splitlines()
+        b64 = b"".join(sl[1:-1])
+        der = b64decode(b64)
+
+        sens = TPM2B_SENSITIVE()
+        crypto.private_from_encoding(der, sens)
+
+    def test_private_from_pem_ecc_der(self):
+        sl = ecc_private_key.strip().splitlines()
+        b64 = b"".join(sl[1:-1])
+        der = b64decode(b64)
+
+        sens = TPM2B_SENSITIVE()
+        crypto.private_from_encoding(der, sens)
+
+    def test_private_from_pem_bad_der(self):
+        der = b"" * 1024
+        pub = TPM2B_PUBLIC()
+        with self.assertRaises(ValueError) as e:
+            crypto.private_from_encoding(der, pub)
         self.assertEqual(str(e.exception), "Unsupported key format")

--- a/tpm2_pytss/crypto.py
+++ b/tpm2_pytss/crypto.py
@@ -135,11 +135,11 @@ def private_from_encoding(data, obj):
     key = private_key_from_encoding(data)
     nums = key.private_numbers()
     if isinstance(key, rsa.RSAPrivateKey):
-        obj.sensitiveArea.sensitiveType = lib.TPM2_ALG_RSA
-        _int_to_buffer(nums.p, obj.sensitiveArea.sensitive.rsa)
+        obj.sensitiveType = lib.TPM2_ALG_RSA
+        _int_to_buffer(nums.p, obj.sensitive.rsa)
     elif isinstance(key, ec.EllipticCurvePrivateKey):
-        obj.sensitiveArea.sensitiveType = lib.TPM2_ALG_ECC
-        _int_to_buffer(nums.private_value, obj.sensitiveArea.sensitive.ecc)
+        obj.sensitiveType = lib.TPM2_ALG_ECC
+        _int_to_buffer(nums.private_value, obj.sensitive.ecc)
     else:
         raise RuntimeError(f"unsupported key type: {key.__class__.__name__}")
 

--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -1728,9 +1728,8 @@ class TPM2B_PUBLIC_KEY_RSA(TPM2B_SIMPLE_OBJECT):
 class TPM2B_SENSITIVE(TPM_OBJECT):
     @classmethod
     def fromPEM(cls, data):
-        p = cls()
-        private_from_encoding(data, p)
-        return p
+        p = TPMT_SENSITIVE.fromPEM(data)
+        return cls(sensitiveArea=p)
 
 
 class TPM2B_SENSITIVE_CREATE(TPM_OBJECT):
@@ -2115,7 +2114,11 @@ class TPMU_PUBLIC_ID(TPM_OBJECT):
 
 
 class TPMT_SENSITIVE(TPM_OBJECT):
-    pass
+    @classmethod
+    def fromPEM(cls, data):
+        p = cls()
+        private_from_encoding(data, p)
+        return p
 
 
 class TPMU_SENSITIVE_COMPOSITE(TPM_OBJECT):

--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -15,7 +15,7 @@ from tpm2_pytss.utils import (
 )
 from tpm2_pytss.crypto import (
     public_from_encoding,
-    private_from_pem,
+    private_from_encoding,
     public_to_pem,
     getname,
 )
@@ -1729,7 +1729,7 @@ class TPM2B_SENSITIVE(TPM_OBJECT):
     @classmethod
     def fromPEM(cls, data):
         p = cls()
-        private_from_pem(data, p)
+        private_from_encoding(data, p)
         return p
 
 


### PR DESCRIPTION
If we support pure DER for public keys we should probably support it for private keys as well.

Also move fromPEM to TPMT_SENSITIVE