### PR TITLE
Normalize NV API

### DIFF
--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -279,9 +279,7 @@ class CryptoTest(TSS2_EsapiTest):
         oname = nv.getName()
         nv2b = TPM2B_NV_PUBLIC(nvPublic=nv)
 
-        handle = self.ectx.NV_DefineSpace(
-            ESYS_TR.RH_OWNER, b"1234", nv2b, session1=ESYS_TR.PASSWORD
-        )
+        handle = self.ectx.NV_DefineSpace(b"1234", nv2b)
 
         ename = self.ectx.TR_GetName(handle)
 

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -145,7 +145,7 @@ class TestEsys(TSS2_EsapiTest):
         )
 
         # No password NV index
-        nv_index = self.ectx.NV_DefineSpace(ESYS_TR.OWNER, None, nv_public)
+        nv_index = self.ectx.NV_DefineSpace(None, nv_public)
         self.ectx.NV_Write(nv_index, b"hello world")
 
         value = self.ectx.NV_Read(nv_index, 11)
@@ -167,7 +167,7 @@ class TestEsys(TSS2_EsapiTest):
         self.assertEqual(len(n), 68)
         self.assertTrue(isinstance(n, str))
 
-        self.ectx.NV_UndefineSpace(ESYS_TR.OWNER, nv_index)
+        self.ectx.NV_UndefineSpace(nv_index)
 
         with self.assertRaises(TSS2_Exception):
             public, name = self.ectx.NV_ReadPublic(nv_index)
@@ -1750,7 +1750,7 @@ class TestEsys(TSS2_EsapiTest):
             )
         )
 
-        nvhandle = self.ectx.NV_DefineSpace(ESYS_TR.RH_PLATFORM, b"", nvpub)
+        nvhandle = self.ectx.NV_DefineSpace(b"", nvpub, authHandle=ESYS_TR.RH_PLATFORM)
 
         session = self.ectx.StartAuthSession(
             ESYS_TR.NONE,
@@ -1764,7 +1764,7 @@ class TestEsys(TSS2_EsapiTest):
         self.ectx.PolicyCommandCode(session, TPM2_CC.NV_UndefineSpaceSpecial)
 
         self.ectx.NV_UndefineSpaceSpecial(
-            nvhandle, ESYS_TR.RH_PLATFORM, session1=session, session2=ESYS_TR.PASSWORD
+            nvhandle, session1=session, session2=ESYS_TR.PASSWORD
         )
 
     def test_NV_ReadPublic(self):
@@ -1778,7 +1778,7 @@ class TestEsys(TSS2_EsapiTest):
             )
         )
 
-        nvhandle = self.ectx.NV_DefineSpace(ESYS_TR.RH_OWNER, b"", nvpub)
+        nvhandle = self.ectx.NV_DefineSpace(b"", nvpub)
 
         pubout, name = self.ectx.NV_ReadPublic(nvhandle)
 
@@ -1797,9 +1797,9 @@ class TestEsys(TSS2_EsapiTest):
             )
         )
 
-        nvhandle = self.ectx.NV_DefineSpace(ESYS_TR.RH_OWNER, b"", nvpub)
+        nvhandle = self.ectx.NV_DefineSpace(b"", nvpub)
 
-        self.ectx.NV_Increment(ESYS_TR.RH_OWNER, nvhandle, session1=ESYS_TR.PASSWORD)
+        self.ectx.NV_Increment(nvhandle, authHandle=ESYS_TR.RH_OWNER)
 
         data = self.ectx.NV_Read(nvhandle, 8, 0, authHandle=ESYS_TR.RH_OWNER)
 
@@ -1819,12 +1819,10 @@ class TestEsys(TSS2_EsapiTest):
             )
         )
 
-        nvhandle = self.ectx.NV_DefineSpace(ESYS_TR.RH_OWNER, b"", nvpub)
+        nvhandle = self.ectx.NV_DefineSpace(b"", nvpub)
 
         edata = b"\xFF" * 32
-        self.ectx.NV_Extend(
-            ESYS_TR.RH_OWNER, nvhandle, edata, session1=ESYS_TR.PASSWORD
-        )
+        self.ectx.NV_Extend(nvhandle, edata, authHandle=ESYS_TR.RH_OWNER)
 
         data = self.ectx.NV_Read(nvhandle, 32, 0, authHandle=ESYS_TR.RH_OWNER)
 
@@ -1844,12 +1842,10 @@ class TestEsys(TSS2_EsapiTest):
             )
         )
 
-        nvhandle = self.ectx.NV_DefineSpace(ESYS_TR.RH_OWNER, b"", nvpub)
+        nvhandle = self.ectx.NV_DefineSpace(b"", nvpub)
 
         bits = 0b1010
-        self.ectx.NV_SetBits(
-            ESYS_TR.RH_OWNER, nvhandle, bits, session1=ESYS_TR.PASSWORD
-        )
+        self.ectx.NV_SetBits(nvhandle, bits, authHandle=ESYS_TR.RH_OWNER)
 
         data = self.ectx.NV_Read(nvhandle, 8, 0, authHandle=ESYS_TR.RH_OWNER)
 
@@ -1869,9 +1865,9 @@ class TestEsys(TSS2_EsapiTest):
             )
         )
 
-        nvhandle = self.ectx.NV_DefineSpace(ESYS_TR.RH_OWNER, b"", nvpub)
+        nvhandle = self.ectx.NV_DefineSpace(b"", nvpub)
 
-        self.ectx.NV_WriteLock(ESYS_TR.RH_OWNER, nvhandle, session1=ESYS_TR.PASSWORD)
+        self.ectx.NV_WriteLock(nvhandle, authHandle=ESYS_TR.RH_OWNER)
 
         indata = b"12345678"
         with self.assertRaises(TSS2_Exception) as e:
@@ -1890,9 +1886,9 @@ class TestEsys(TSS2_EsapiTest):
             )
         )
 
-        nvhandle = self.ectx.NV_DefineSpace(ESYS_TR.RH_OWNER, b"", nvpub)
+        nvhandle = self.ectx.NV_DefineSpace(b"", nvpub)
 
-        self.ectx.NV_GlobalWriteLock(ESYS_TR.RH_OWNER, session1=ESYS_TR.PASSWORD)
+        self.ectx.NV_GlobalWriteLock()
 
         indata = b"12345678"
         with self.assertRaises(TSS2_Exception) as e:
@@ -1913,12 +1909,12 @@ class TestEsys(TSS2_EsapiTest):
             )
         )
 
-        nvhandle = self.ectx.NV_DefineSpace(ESYS_TR.RH_OWNER, b"", nvpub)
+        nvhandle = self.ectx.NV_DefineSpace(b"", nvpub)
 
         indata = b"12345678"
         self.ectx.NV_Write(nvhandle, indata, authHandle=ESYS_TR.RH_OWNER)
 
-        self.ectx.NV_ReadLock(ESYS_TR.RH_OWNER, nvhandle, session1=ESYS_TR.PASSWORD)
+        self.ectx.NV_ReadLock(nvhandle, authHandle=ESYS_TR.RH_OWNER)
         with self.assertRaises(TSS2_Exception) as e:
             self.ectx.NV_Read(nvhandle, 8, authHandle=ESYS_TR.RH_OWNER)
 
@@ -1937,7 +1933,7 @@ class TestEsys(TSS2_EsapiTest):
             )
         )
 
-        nvhandle = self.ectx.NV_DefineSpace(ESYS_TR.RH_OWNER, b"first", nvpub)
+        nvhandle = self.ectx.NV_DefineSpace(b"first", nvpub)
         self.ectx.NV_Write(nvhandle, b"sometest", authHandle=ESYS_TR.RH_OWNER)
 
         self.ectx.NV_Read(nvhandle, 8, authHandle=nvhandle)
@@ -1968,7 +1964,7 @@ class TestEsys(TSS2_EsapiTest):
             )
         )
 
-        nvhandle = self.ectx.NV_DefineSpace(ESYS_TR.RH_OWNER, b"", nvpub)
+        nvhandle = self.ectx.NV_DefineSpace(b"", nvpub)
         self.ectx.NV_Write(nvhandle, b"sometest", authHandle=ESYS_TR.RH_OWNER)
 
         inPublic = TPM2B_PUBLIC(
@@ -1990,12 +1986,11 @@ class TestEsys(TSS2_EsapiTest):
 
         certifyInfo, _ = self.ectx.NV_Certify(
             eccHandle,
-            ESYS_TR.RH_OWNER,
             nvhandle,
             qualifyingData,
             inScheme,
             8,
-            0,
+            authHandle=ESYS_TR.RH_OWNER,
             session1=ESYS_TR.PASSWORD,
             session2=ESYS_TR.PASSWORD,
         )

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -2661,15 +2661,18 @@ class ESAPI:
 
     def NV_DefineSpace(
         self,
-        authHandle,
         auth,
         publicInfo,
+        authHandle=ESYS_TR.OWNER,
         session1=ESYS_TR.PASSWORD,
         session2=ESYS_TR.NONE,
         session3=ESYS_TR.NONE,
     ):
 
         check_handle_type(authHandle, "authHandle")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
         auth_cdata = get_cdata(auth, TPM2B_AUTH, "auth", allow_none=True)
         publicInfo_cdata = get_cdata(publicInfo, TPM2B_NV_PUBLIC, "publicInfo")
         nvHandle = ffi.new("ESYS_TR *")
@@ -2690,8 +2693,8 @@ class ESAPI:
 
     def NV_UndefineSpace(
         self,
-        authHandle,
         nvIndex,
+        authHandle=ESYS_TR.RH_OWNER,
         session1=ESYS_TR.PASSWORD,
         session2=ESYS_TR.NONE,
         session3=ESYS_TR.NONE,
@@ -2699,6 +2702,9 @@ class ESAPI:
 
         check_handle_type(authHandle, "authHandle")
         check_handle_type(nvIndex, "nvIndex")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
         _chkrc(
             lib.Esys_NV_UndefineSpace(
                 self.ctx, authHandle, nvIndex, session1, session2, session3
@@ -2708,7 +2714,7 @@ class ESAPI:
     def NV_UndefineSpaceSpecial(
         self,
         nvIndex,
-        platform,
+        platform=ESYS_TR.RH_PLATFORM,
         session1=ESYS_TR.NONE,
         session2=ESYS_TR.NONE,
         session3=ESYS_TR.NONE,
@@ -2716,6 +2722,9 @@ class ESAPI:
 
         check_handle_type(nvIndex, "nvIndex")
         check_handle_type(platform, "platform")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
         _chkrc(
             lib.Esys_NV_UndefineSpaceSpecial(
                 self.ctx, nvIndex, platform, session1, session2, session3
@@ -2731,6 +2740,9 @@ class ESAPI:
     ):
 
         check_handle_type(nvIndex, "nvIndex")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
         nvPublic = ffi.new("TPM2B_NV_PUBLIC **")
         nvName = ffi.new("TPM2B_NAME **")
         _chkrc(
@@ -2758,6 +2770,9 @@ class ESAPI:
             authHandle = nvIndex
         check_handle_type(nvIndex, "nvIndex")
         check_handle_type(authHandle, "authHandle")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
         data_cdata = get_cdata(data, TPM2B_MAX_NV_BUFFER, "data")
         _chkrc(
             lib.Esys_NV_Write(
@@ -2774,15 +2789,20 @@ class ESAPI:
 
     def NV_Increment(
         self,
-        authHandle,
         nvIndex,
-        session1=ESYS_TR.NONE,
+        authHandle=0,
+        session1=ESYS_TR.PASSWORD,
         session2=ESYS_TR.NONE,
         session3=ESYS_TR.NONE,
     ):
 
+        if authHandle == 0:
+            authHandle = nvIndex
         check_handle_type(authHandle, "authHandle")
         check_handle_type(nvIndex, "nvIndex")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
         _chkrc(
             lib.Esys_NV_Increment(
                 self.ctx, authHandle, nvIndex, session1, session2, session3
@@ -2791,16 +2811,21 @@ class ESAPI:
 
     def NV_Extend(
         self,
-        authHandle,
         nvIndex,
         data,
-        session1=ESYS_TR.NONE,
+        authHandle=0,
+        session1=ESYS_TR.PASSWORD,
         session2=ESYS_TR.NONE,
         session3=ESYS_TR.NONE,
     ):
 
+        if authHandle == 0:
+            authHandle = nvIndex
         check_handle_type(authHandle, "authHandle")
         check_handle_type(nvIndex, "nvIndex")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
         data_cdata = get_cdata(data, TPM2B_MAX_NV_BUFFER, "data")
         _chkrc(
             lib.Esys_NV_Extend(
@@ -2810,16 +2835,21 @@ class ESAPI:
 
     def NV_SetBits(
         self,
-        authHandle,
         nvIndex,
         bits,
-        session1=ESYS_TR.NONE,
+        authHandle=0,
+        session1=ESYS_TR.PASSWORD,
         session2=ESYS_TR.NONE,
         session3=ESYS_TR.NONE,
     ):
 
+        if authHandle == 0:
+            authHandle = nvIndex
         check_handle_type(authHandle, "authHandle")
         check_handle_type(nvIndex, "nvIndex")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
         _chkrc(
             lib.Esys_NV_SetBits(
                 self.ctx, authHandle, nvIndex, session1, session2, session3, bits
@@ -2828,15 +2858,20 @@ class ESAPI:
 
     def NV_WriteLock(
         self,
-        authHandle,
         nvIndex,
-        session1=ESYS_TR.NONE,
+        authHandle=0,
+        session1=ESYS_TR.PASSWORD,
         session2=ESYS_TR.NONE,
         session3=ESYS_TR.NONE,
     ):
 
+        if authHandle == 0:
+            authHandle = nvIndex
         check_handle_type(authHandle, "authHandle")
         check_handle_type(nvIndex, "nvIndex")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
         _chkrc(
             lib.Esys_NV_WriteLock(
                 self.ctx, authHandle, nvIndex, session1, session2, session3
@@ -2845,13 +2880,16 @@ class ESAPI:
 
     def NV_GlobalWriteLock(
         self,
-        authHandle,
-        session1=ESYS_TR.NONE,
+        authHandle=ESYS_TR.RH_OWNER,
+        session1=ESYS_TR.PASSWORD,
         session2=ESYS_TR.NONE,
         session3=ESYS_TR.NONE,
     ):
 
         check_handle_type(authHandle, "authHandle")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
         _chkrc(
             lib.Esys_NV_GlobalWriteLock(
                 self.ctx, authHandle, session1, session2, session3
@@ -2873,6 +2911,9 @@ class ESAPI:
             authHandle = nvIndex
         check_handle_type(nvIndex, "nvIndex")
         check_handle_type(authHandle, "authHandle")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
         data = ffi.new("TPM2B_MAX_NV_BUFFER **")
         _chkrc(
             lib.Esys_NV_Read(
@@ -2891,15 +2932,20 @@ class ESAPI:
 
     def NV_ReadLock(
         self,
-        authHandle,
         nvIndex,
-        session1=ESYS_TR.NONE,
+        authHandle=0,
+        session1=ESYS_TR.PASSWORD,
         session2=ESYS_TR.NONE,
         session3=ESYS_TR.NONE,
     ):
 
+        if authHandle == 0:
+            authHandle = nvIndex
         check_handle_type(nvIndex, "nvIndex")
         check_handle_type(authHandle, "authHandle")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
         _chkrc(
             lib.Esys_NV_ReadLock(
                 self.ctx, authHandle, nvIndex, session1, session2, session3
@@ -2916,6 +2962,9 @@ class ESAPI:
     ):
 
         check_handle_type(nvIndex, "nvIndex")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
         newAuth_cdata = get_cdata(newAuth, TPM2B_DIGEST, "newAuth")
         _chkrc(
             lib.Esys_NV_ChangeAuth(
@@ -2926,20 +2975,25 @@ class ESAPI:
     def NV_Certify(
         self,
         signHandle,
-        authHandle,
         nvIndex,
         qualifyingData,
         inScheme,
         size,
-        offset,
+        offset=0,
+        authHandle=0,
         session1=ESYS_TR.NONE,
-        session2=ESYS_TR.NONE,
+        session2=ESYS_TR.PASSWORD,
         session3=ESYS_TR.NONE,
     ):
 
+        if authHandle == 0:
+            authHandle = nvIndex
         check_handle_type(signHandle, "signHandle")
         check_handle_type(authHandle, "authHandle")
         check_handle_type(nvIndex, "nvIndex")
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
         qualifyingData_cdata = get_cdata(qualifyingData, TPM2B_DATA, "qualifyingData")
         inScheme_cdata = get_cdata(inScheme, TPMT_SIG_SCHEME, "inScheme")
         certifyInfo = ffi.new("TPM2B_ATTEST **")


### PR DESCRIPTION
This sets the following defaults for the NV API:
* Owner as the hierarchy for (Un)DefineSpace and GlobalWriteLock
* Platform as the hierachy for UndefineSpaceSpecial
* nvIndex as the authHandle for all read/write operations (including {Read,Write}Lock)
* offset to 0 for read operations
