### PR TITLE
add python MakeCredential implementation

### DIFF
--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -248,6 +248,14 @@ class CryptoTest(TSS2_EsapiTest):
 
         self.assertEqual(pem, ecc_public_key)
 
+    def test_public_to_pem_bad_key(self):
+        pub = types.TPM2B_PUBLIC.fromPEM(ecc_public_key)
+        pub.publicArea.type = TPM2_ALG.NULL
+
+        with self.assertRaises(ValueError) as e:
+            pem = crypto.public_to_pem(pub.publicArea)
+        self.assertEqual(str(e.exception), f"unsupported key type: {TPM2_ALG.NULL}")
+
     def test_topem_rsa(self):
         pub = types.TPM2B_PUBLIC.fromPEM(rsa_public_key)
         pem = pub.toPEM()

--- a/test/test_makecred.py
+++ b/test/test_makecred.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python3 -u
+"""
+SPDX-License-Identifier: BSD-2
+"""
+import unittest
+
+from tpm2_pytss import *
+from tpm2_pytss.makecred import *
+from .TSS2_BaseTest import TSS2_EsapiTest
+
+
+class MakeCredTest(TSS2_EsapiTest):
+    def test_generate_seed_rsa(self):
+        insens = TPM2B_SENSITIVE_CREATE()
+        _, public, _, _, _ = self.ectx.CreatePrimary(insens)
+        seed, enc_seed = generate_seed(public.publicArea, b"test")
+
+        public.publicArea.nameAlg = TPM2_ALG.LAST + 1
+        with self.assertRaises(ValueError) as e:
+            generate_seed(public.publicArea, b"test")
+        self.assertEqual(
+            str(e.exception), f"unsupported digest algorithm {TPM2_ALG.LAST + 1}"
+        )
+
+        public.publicArea.type = TPM2_ALG.NULL
+        with self.assertRaises(ValueError) as e:
+            generate_seed(public.publicArea, b"test")
+        self.assertEqual(str(e.exception), f"unsupported key type: {TPM2_ALG.NULL}")
+
+    def test_generate_seed_ecc(self):
+        insens = TPM2B_SENSITIVE_CREATE()
+        _, public, _, _, _ = self.ectx.CreatePrimary(insens, "ecc")
+        seed, enc_seed = generate_seed(public.publicArea, b"test")
+
+        public.publicArea.nameAlg = TPM2_ALG.LAST + 1
+        with self.assertRaises(ValueError) as e:
+            generate_seed(public.publicArea, b"test")
+        self.assertEqual(
+            str(e.exception), f"unsupported digest algorithm {TPM2_ALG.LAST + 1}"
+        )
+
+    def test_MakeCredential_rsa(self):
+        insens = TPM2B_SENSITIVE_CREATE()
+        phandle, parent, _, _, _ = self.ectx.CreatePrimary(insens)
+        private, public, _, _, _ = self.ectx.Create(phandle, insens)
+        credblob, secret = MakeCredential(parent, b"credential data", public.getName())
+        handle = self.ectx.Load(phandle, private, public)
+        certinfo = self.ectx.ActivateCredential(handle, phandle, credblob, secret)
+        self.assertEqual(b"credential data", bytes(certinfo))
+
+    def test_MakeCredential_ecc(self):
+        insens = TPM2B_SENSITIVE_CREATE()
+        phandle, parent, _, _, _ = self.ectx.CreatePrimary(insens, "ecc")
+        private, public, _, _, _ = self.ectx.Create(phandle, insens, "ecc")
+        credblob, secret = MakeCredential(parent, b"credential data", public.getName())
+        handle = self.ectx.Load(phandle, private, public)
+        certinfo = self.ectx.ActivateCredential(handle, phandle, credblob, secret)
+        self.assertEqual(b"credential data", bytes(certinfo))

--- a/tpm2_pytss/crypto.py
+++ b/tpm2_pytss/crypto.py
@@ -144,7 +144,7 @@ def private_from_encoding(data, obj):
         raise RuntimeError(f"unsupported key type: {key.__class__.__name__}")
 
 
-def public_to_pem(obj):
+def public_to_key(obj):
     key = None
     if obj.type == lib.TPM2_ALG_RSA:
         b = obj.unique.rsa.buffer
@@ -165,7 +165,13 @@ def public_to_pem(obj):
         nums = ec.EllipticCurvePublicNumbers(x, y, curve())
         key = nums.public_key(backend=default_backend())
     else:
-        raise RuntimeError(f"unsupported key type: {obj.publicArea.type}")
+        raise ValueError(f"unsupported key type: {obj.type}")
+
+    return key
+
+
+def public_to_pem(obj):
+    key = public_to_key(obj)
     return key.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo)
 
 

--- a/tpm2_pytss/makecred.py
+++ b/tpm2_pytss/makecred.py
@@ -1,0 +1,98 @@
+from .crypto import (
+    kdfa,
+    kdfe,
+    public_to_key,
+    _get_digest,
+    symdef_to_crypt,
+)
+from .types import *
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.ec import (
+    ECDH,
+    generate_private_key,
+)
+from cryptography.hazmat.primitives.hmac import HMAC
+from cryptography.hazmat.primitives.ciphers import modes, Cipher
+from cryptography.hazmat.backends import default_backend
+import secrets
+
+
+def generate_rsa_seed(key, hashAlg, label):
+    halg = _get_digest(hashAlg)
+    if halg is None:
+        raise ValueError(f"unsupported digest algorithm {hashAlg}")
+    seed = secrets.token_bytes(halg.digest_size)
+    mgf = padding.MGF1(halg())
+    padd = padding.OAEP(mgf, halg(), label)
+    enc_seed = key.encrypt(seed, padd)
+    return (seed, enc_seed)
+
+
+def generate_ecc_seed(key, hashAlg, label):
+    halg = _get_digest(hashAlg)
+    if halg is None:
+        raise ValueError(f"unsupported digest algorithm {hashAlg}")
+    ekey = generate_private_key(key.curve, default_backend())
+    epubnum = ekey.public_key().public_numbers()
+    plength = int(key.curve.key_size / 8)  # FIXME ceiling here
+    exbytes = epubnum.x.to_bytes(plength, "big")
+    eybytes = epubnum.y.to_bytes(plength, "big")
+    epoint = TPMS_ECC_POINT(
+        x=TPM2B_ECC_PARAMETER(buffer=exbytes), y=TPM2B_ECC_PARAMETER(buffer=eybytes)
+    )
+    secret = epoint.Marshal()
+    shared_key = ekey.exchange(ECDH(), key)
+    pubnum = key.public_numbers()
+    xbytes = pubnum.x.to_bytes(plength, "big")
+    seed = kdfe(hashAlg, shared_key, label, exbytes, xbytes, halg.digest_size * 8)
+    return (seed, secret)
+
+
+def generate_seed(public, label):
+    key = public_to_key(public)
+    if public.type == TPM2_ALG.RSA:
+        return generate_rsa_seed(key, public.nameAlg, label)
+    elif public.type == TPM2_ALG.ECC:
+        return generate_ecc_seed(key, public.nameAlg, label)
+    else:
+        raise ValueError(f"unsupported seed algorithm {public.type}")
+
+
+def hmac(halg, hmackey, enc_cred, name):
+    h = HMAC(hmackey, halg(), backend=default_backend())
+    h.update(enc_cred)
+    h.update(name)
+    return h.finalize()
+
+
+def encrypt(cipher, key, data):
+    iv = len(key) * b"\x00"
+    ci = cipher(key)
+    ciph = Cipher(ci, modes.CFB(iv), backend=default_backend())
+    encr = ciph.encryptor()
+    encdata = encr.update(data) + encr.finalize()
+    return encdata
+
+
+def MakeCredential(public, credential, name):
+    if isinstance(public, TPM2B_PUBLIC):
+        public = public.publicArea
+    if isinstance(credential, bytes):
+        credential = TPM2B_DIGEST(buffer=credential)
+    if isinstance(name, TPM2B_SIMPLE_OBJECT):
+        name = bytes(name)
+    seed, enc_seed = generate_seed(public, b"IDENTITY\x00")
+
+    (cipher, symmode, symbits) = symdef_to_crypt(public.parameters.asymDetail.symmetric)
+    symkey = kdfa(public.nameAlg, seed, b"STORAGE", name, b"", symbits)
+
+    enc_cred = encrypt(cipher, symkey, credential.Marshal())
+
+    halg = _get_digest(public.nameAlg)
+    hmackey = kdfa(public.nameAlg, seed, b"INTEGRITY", b"", b"", halg.digest_size * 8)
+    outerhmac = hmac(halg, hmackey, enc_cred, name)
+    hmacdata = TPM2B_DIGEST(buffer=outerhmac).Marshal()
+
+    credblob = TPM2B_ID_OBJECT(credential=hmacdata + enc_cred)
+    secret = TPM2B_ENCRYPTED_SECRET(secret=enc_seed)
+    return (credblob, secret)


### PR DESCRIPTION
This will add a MakeCredential implementation without the need for a TPM (simulator) and lay the foundation for the duplicate protocol 