### PR TITLE
dd public_to_key function

### DIFF
--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -248,6 +248,14 @@ class CryptoTest(TSS2_EsapiTest):
 
         self.assertEqual(pem, ecc_public_key)
 
+    def test_public_to_pem_bad_key(self):
+        pub = types.TPM2B_PUBLIC.fromPEM(ecc_public_key)
+        pub.publicArea.type = TPM2_ALG.NULL
+
+        with self.assertRaises(ValueError) as e:
+            pem = crypto.public_to_pem(pub.publicArea)
+        self.assertEqual(str(e.exception), f"unsupported key type: {TPM2_ALG.NULL}")
+
     def test_topem_rsa(self):
         pub = types.TPM2B_PUBLIC.fromPEM(rsa_public_key)
         pem = pub.toPEM()

--- a/tpm2_pytss/crypto.py
+++ b/tpm2_pytss/crypto.py
@@ -144,7 +144,7 @@ def private_from_encoding(data, obj):
         raise RuntimeError(f"unsupported key type: {key.__class__.__name__}")
 
 
-def public_to_pem(obj):
+def public_to_key(obj):
     key = None
     if obj.type == lib.TPM2_ALG_RSA:
         b = obj.unique.rsa.buffer
@@ -165,7 +165,13 @@ def public_to_pem(obj):
         nums = ec.EllipticCurvePublicNumbers(x, y, curve())
         key = nums.public_key(backend=default_backend())
     else:
-        raise RuntimeError(f"unsupported key type: {obj.publicArea.type}")
+        raise ValueError(f"unsupported key type: {obj.type}")
+
+    return key
+
+
+def public_to_pem(obj):
+    key = public_to_key(obj)
     return key.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo)
 
 


### PR DESCRIPTION
This separates TPM to cryptography key conversion from the encoding.

I need this for the MakeCredential code but I see other use cases as well, for example extracting the key to do signature verification. That's why it's a separate PR. 