### PR TITLE
requirements: update urllib3 to 1.26.5

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -28,4 +28,4 @@ sphinxcontrib-htmlhelp==1.0.3
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
-urllib3==1.26.4
+urllib3==1.26.5


### PR DESCRIPTION
urllib3 versions < 1.26.5 contain CVE-2021-33503. Update the version to
something with this patched.

Signed-off-by: William Roberts <william.c.roberts@intel.com>