### PR TITLE
crypto: fix missing backend argument

### DIFF
--- a/tpm2_pytss/crypto.py
+++ b/tpm2_pytss/crypto.py
@@ -135,10 +135,10 @@ def private_key_from_encoding(data):
     if sdata.startswith(b"-----BEGIN RSA PRIVATE KEY-----") or sdata.startswith(
         b"-----BEGIN EC PRIVATE KEY-----"
     ):
-        key = load_pem_private_key(sdata, password=None)
+        key = load_pem_private_key(sdata, password=None, backend=default_backend())
     else:
         try:
-            key = load_der_private_key(data, password=None)
+            key = load_der_private_key(data, password=None, backend=default_backend())
         except ValueError:
             pass
 


### PR DESCRIPTION
Fixes errors like:
    def private_key_from_encoding(data):
        sdata = data.strip()
        key = None
        if sdata.startswith(b"-----BEGIN RSA PRIVATE KEY-----") or sdata.startswith(
            b"-----BEGIN EC PRIVATE KEY-----"
        ):
            key = load_pem_private_key(sdata, password=None)
        else:
            try:
>               key = load_der_private_key(data, password=None)
E               TypeError: load_der_private_key() missing 1 required positional argument: 'backend'

Signed-off-by: William Roberts <william.c.roberts@intel.com>