### PR TITLE
FAPI: fix provision acceptable rcs

### DIFF
--- a/tpm2_pytss/FAPI.py
+++ b/tpm2_pytss/FAPI.py
@@ -210,7 +210,7 @@ class FAPI:
         )
         _chkrc(
             ret,
-            acceptable=lib.TSS2_FAPI_RC_ALREADY_PROVISIONED
+            acceptable=[lib.TSS2_FAPI_RC_ALREADY_PROVISIONED]
             if is_provisioned_ok
             else None,
         )


### PR DESCRIPTION
FAPI provision can fail with already provisioned, which is OK. However,
the _chkrc function takes a list of acceptable RC's to check against
before raising the exception. However, FAPI provision passed just an
int, not a list and generates the following error:

ERROR:fapi:src/tss2-fapi/api/Fapi_Provision.c:1473:Fapi_Provision_Finish() ErrorCode (0x00060025) No EK certifcate found for current crypto profile found. You may want to switch the profile in fapi-config or set the ek_cert_less or ek_cert_file options in fapi-config. See also https://tpm2-software.github.io/2020/07/22/Fapi_Crypto_Profiles.html
ERROR:fapi:src/tss2-fapi/api/Fapi_Provision.c:168:Fapi_Provision() ErrorCode (0x00060025) Provision
Traceback (most recent call last):
  File "a.py", line 4, in <module>
    fapi.provision()
  File "/home/wcrobert/workspace/tpm2-pytss/tpm2_pytss/FAPI.py", line 211, in provision
    _chkrc(
  File "/home/wcrobert/workspace/tpm2-pytss/tpm2_pytss/utils.py", line 17, in _chkrc
    if acceptable is not None and (rc == acceptable or rc in acceptable):
TypeError: argument of type 'int' is not iterable

Fix this by specifying a list.

Signed-off-by: William Roberts <william.c.roberts@intel.com>