### PR TITLE
add TCTI class for the TCTI API

### DIFF
--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -3411,6 +3411,12 @@ class TestEsys(TSS2_EsapiTest):
         with self.assertRaises(TypeError):
             self.ectx.PCR_Reset(ESYS_TR.PCR20, session3=45.6)
 
+    def test_gettcti(self):
+        tcti = self.ectx.GetTcti()
+        self.assertTrue(isinstance(tcti, TCTI))
+
+        self.assertEqual(tcti, self.ectx.tcti)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_fapi.py
+++ b/test/test_fapi.py
@@ -5,7 +5,6 @@ SPDX-License-Identifier: BSD-2
 import binascii
 import random
 import string
-from types import SimpleNamespace
 
 import pkgconfig
 
@@ -71,10 +70,7 @@ def init_fapi(request, fapi):
 class TestFapi:
     @pytest.fixture
     def esys(self):
-        # TODO ESAPI should accept either a cdata obj or a dedicated TCTI class, not TctiLdr!
-        tcti = SimpleNamespace()
-        tcti.ctx = self.fapi.tcti
-        with ESAPI(tcti=tcti) as esys:
+        with ESAPI(tcti=self.fapi.tcti) as esys:
             yield esys
 
     @pytest.fixture

--- a/test/test_tcti.py
+++ b/test/test_tcti.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python3 -u
+"""
+SPDX-License-Identifier: BSD-2
+"""
+
+import unittest
+
+from tpm2_pytss import *
+from .TSS2_BaseTest import TSS2_EsapiTest
+
+
+class TestTCTI(TSS2_EsapiTest):
+    def test_init(self):
+        self.assertEqual(self.tcti.version, 2)
+        self.assertGreater(self.tcti.magic, 0)
+
+        v1ctx = ffi.cast("TSS2_TCTI_CONTEXT_COMMON_V1 *", self.tcti._ctx)
+        v1ctx.version = 1
+
+        tcti = TCTI(self.tcti._ctx)
+        self.assertEqual(tcti.version, 1)
+        self.assertEqual(tcti._v2, None)
+
+    def test_transmit_receive(self):
+        startup = b"\x80\x01\x00\x00\x00\x0C\x00\x00\x01\x44\x00\x00"
+        self.tcti.transmit(startup)
+
+        resp = self.tcti.receive()
+        self.assertEqual(resp, b"\x80\x01\x00\x00\x00\n\x00\x00\x01\x00")
+
+    def test_finalize(self):
+        tcti = TCTI(self.tcti._ctx)
+        tcti.finalize()
+
+    def test_cancel(self):
+        if getattr(self.tcti, "name", "") == "swtpm":
+            self.skipTest("cancel supported by swtpm")
+
+        startup = b"\x80\x01\x00\x00\x00\x0C\x00\x00\x01\x44\x00\x00"
+        self.tcti.transmit(startup)
+        self.tcti.cancel()
+
+    def test_get_poll_handles(self):
+        tcti_name = getattr(self.tcti, "name", "")
+        try:
+            handles = self.tcti.get_poll_handles()
+        except TSS2_Exception as e:
+            if e.rc != lib.TSS2_TCTI_RC_NOT_IMPLEMENTED:
+                raise e
+            else:
+                self.skipTest(f"get_poll_handles not supported by {tcti_name}")
+
+    def test_set_locality(self):
+        self.tcti.set_locality(TPMA_LOCALITY.TWO)
+
+    def test_make_sticky(self):
+        tcti_name = getattr(self.tcti, "name", "")
+        if tcti_name in ("swtpm", "mssim"):
+            self.skipTest(f"make_sticky not supported by {tcti_name}")
+        raise Exception(self.tcti.name)
+        self.tcti.make_sticky(0, 0)
+
+        tcti._v2 = None
+        with self.assertRaises(RuntimeError) as e:
+            self.tcti.make_sticky(0, 0)
+        self.assertEqual(str(e.exception), "unsupported by TCTI API version")

--- a/tpm2_pytss/FAPI.py
+++ b/tpm2_pytss/FAPI.py
@@ -12,6 +12,7 @@ from ._libtpm2_pytss import ffi, lib
 from .callbacks import Callback, CallbackType, get_callback, unlock_callback
 from .fapi_info import FapiInfo
 from .utils import _chkrc, to_bytes_or_null
+from .TCTI import TCTI
 
 logger = logging.getLogger(__name__)
 
@@ -178,7 +179,7 @@ class FAPI:
         # returns the actual tcti context, not a copy (so no extra memory is allocated by the fapi)
         ret = lib.Fapi_GetTcti(self.ctx, tcti)
         _chkrc(ret)
-        return tcti[0]
+        return TCTI(tcti[0])
 
     def provision(
         self,

--- a/tpm2_pytss/TCTI.py
+++ b/tpm2_pytss/TCTI.py
@@ -1,0 +1,70 @@
+"""
+SPDX-License-Identifier: BSD-2
+"""
+
+from ._libtpm2_pytss import ffi
+
+from .utils import _chkrc
+
+
+class TCTI:
+    def __init__(self, ctx):
+        self._v1 = ffi.cast("TSS2_TCTI_CONTEXT_COMMON_V1 *", ctx)
+        if self._v1.version == 2:
+            self._v2 = ffi.cast("TSS2_TCTI_CONTEXT_COMMON_V2 *", ctx)
+        else:
+            self._v2 = None
+        self._ctx = ctx
+
+    @property
+    def _tcti_context(self):
+        return self._ctx
+
+    @property
+    def magic(self):
+        return self._v1.magic
+
+    @property
+    def version(self):
+        return self._v1.version
+
+    def transmit(self, command):
+        cmd = ffi.new("uint8_t []", command)
+        clen = len(command)
+        _chkrc(self._v1.transmit(self._ctx, clen, cmd))
+
+    def receive(self, size=-1, timeout=-1):
+        if size == -1:
+            size = 4096
+        resp = ffi.new("uint8_t []", b"\x00" * size)
+        rsize = ffi.new("size_t *", size)
+        _chkrc(self._v1.receive(self._ctx, rsize, resp, timeout))
+        return bytes(ffi.buffer(resp, rsize[0]))
+
+    def finalize(self):
+        self._v1.finalize(self._ctx)
+
+    def cancel(self):
+        _chkrc(self._v1.cancel(self._ctx))
+
+    def get_poll_handles(self):
+        nhandles = ffi.new("size_t *", 0)
+        _chkrc(self._v1.getPollHandles(self._ctx, ffi.NULL, nhandles))
+        if nhandles[0] == 0:
+            return ()
+        handles = ffi.new("TSS2_TCTI_POLL_HANDLE []", nhandles[0])
+        _chkrc(self._v1.getPollHandles(self._ctx, handles, nhandles))
+        rh = []
+        for i in range(0, nhandles[0]):
+            rh.append(handles[i])
+        return tuple(rh)
+
+    def set_locality(self, locality):
+        _chkrc(self._v1.setLocality(self._ctx, locality))
+
+    def make_sticky(self, handle, sticky):
+        if self._v2 is None:
+            raise RuntimeError("unsupported by TCTI API version")
+        hptr = ffi.new("TPM2_HANDLE *", handle)
+        _chkrc(self._v2.makeSticky(self._ctx, hptr, sticky))
+        return hptr[0]

--- a/tpm2_pytss/TctiLdr.py
+++ b/tpm2_pytss/TctiLdr.py
@@ -3,11 +3,11 @@ SPDX-License-Identifier: BSD-2
 """
 
 from ._libtpm2_pytss import lib, ffi
-
+from .TCTI import TCTI
 from .utils import _chkrc
 
 
-class TctiLdr:
+class TctiLdr(TCTI):
     def __init__(self, name=None, conf=None):
 
         self._ctx_pp = ffi.new("TSS2_TCTI_CONTEXT **")
@@ -29,7 +29,9 @@ class TctiLdr:
             raise RuntimeError(f"name must be of type bytes, got {type(name)}")
 
         _chkrc(lib.Tss2_TctiLdr_Initialize_Ex(name, conf, self._ctx_pp))
-        self._ctx = self._ctx_pp[0]
+        super().__init__(self._ctx_pp[0])
+        self._name = name.decode()
+        self._conf = conf.decode()
 
     def __enter__(self):
         return self
@@ -42,5 +44,9 @@ class TctiLdr:
         self._ctx = ffi.NULL
 
     @property
-    def ctx(self):
-        return self._ctx
+    def name(self):
+        return self._name
+
+    @property
+    def conf(self):
+        return self._conf

--- a/tpm2_pytss/__init__.py
+++ b/tpm2_pytss/__init__.py
@@ -1,5 +1,6 @@
 from .ESAPI import ESAPI
 from .FAPI import *
 from .TctiLdr import *
+from .TCTI import TCTI
 from .types import *
 from .TSS2_Exception import TSS2_Exception


### PR DESCRIPTION
With this a clear API for passing a TCTI context is possible.
As well as providing access to the low level TCTI API

Related to https://github.com/tpm2-software/tpm2-pytss/issues/55

I'm not able to test get_poll_handles for an unknown reason (mssim should be able to handle it), might be something with how the bindings are being generated and built.
But I'm not so sure that it's useful at all, I just added it for completeness.

The same issue with testing exists for make_sticky as mssim doesn't support it either, but I think it's useful if you want use for example the linux kernel methods for dealing with TPM keys.

If this is merged I'll make another PR so that TctiLdr return an (sub-)instance off the TCTI class and that ESAPI and FAPI will expect the tcti_context property