### PR TITLE
Esapi testing (PolicySecret and PolicyTicket)

### DIFF
--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -3707,6 +3707,104 @@ class TestEsys(TSS2_EsapiTest):
                 ESYS_TR.OWNER, session, nonce, b"", b"", expiration, session3=56.7
             )
 
+    def test_PolicyTicket(self):
+        handle = self.ectx.CreatePrimary(
+            TPM2B_SENSITIVE_CREATE(),
+            TPM2B_PUBLIC.parse(
+                "rsa:rsapss:null",
+                TPMA_OBJECT.USERWITHAUTH
+                | TPMA_OBJECT.SIGN_ENCRYPT
+                | TPMA_OBJECT.FIXEDTPM
+                | TPMA_OBJECT.FIXEDPARENT
+                | TPMA_OBJECT.SENSITIVEDATAORIGIN,
+            ),
+        )[0]
+
+        sym = TPMT_SYM_DEF(algorithm=TPM2_ALG.NULL)
+
+        session = self.ectx.StartAuthSession(
+            tpmKey=ESYS_TR.NONE,
+            bind=ESYS_TR.NONE,
+            nonceCaller=None,
+            sessionType=TPM2_SE.POLICY,
+            symmetric=sym,
+            authHash=TPM2_ALG.SHA256,
+        )
+
+        nonce = self.ectx.TRSess_GetNonceTPM(session)
+
+        sequence = self.ectx.HashSequenceStart(None, TPM2_ALG.SHA256)
+
+        self.ectx.SequenceUpdate(sequence, TPM2B_MAX_BUFFER(bytes(nonce)))
+
+        # 10 year expiration
+        expiration = -(10 * 365 * 24 * 60 * 60)
+        expbytes = expiration.to_bytes(4, byteorder="big", signed=True)
+
+        digest = self.ectx.SequenceComplete(sequence, expbytes, ESYS_TR.OWNER)[0]
+
+        scheme = TPMT_SIG_SCHEME(scheme=TPM2_ALG.NULL)
+        hash_validation = TPMT_TK_HASHCHECK(
+            tag=TPM2_ST.HASHCHECK, hierarchy=TPM2_RH.OWNER
+        )
+
+        signature = self.ectx.Sign(handle, digest, scheme, hash_validation)
+
+        timeout, policy_ticket = self.ectx.PolicySigned(
+            handle, session, nonce, b"", b"", expiration, signature
+        )
+
+        self.ectx.FlushContext(session)
+
+        session = self.ectx.StartAuthSession(
+            tpmKey=ESYS_TR.NONE,
+            bind=ESYS_TR.NONE,
+            nonceCaller=None,
+            sessionType=TPM2_SE.POLICY,
+            symmetric=sym,
+            authHash=TPM2_ALG.SHA256,
+        )
+
+        name = self.ectx.TR_GetName(handle)
+        self.ectx.PolicyTicket(session, timeout, b"", b"", name, policy_ticket)
+
+        with self.assertRaises(TypeError):
+            self.ectx.PolicyTicket(
+                "notasession", timeout, b"", b"", name, policy_ticket
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.PolicyTicket(session, object(), b"", b"", name, policy_ticket)
+
+        with self.assertRaises(TypeError):
+            self.ectx.PolicyTicket(
+                session, timeout, TPM2B_AUTH, b"", name, policy_ticket
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.PolicyTicket(session, timeout, b"", object(), name, policy_ticket)
+
+        with self.assertRaises(TypeError):
+            self.ectx.PolicyTicket(session, timeout, b"", b"", [], policy_ticket)
+
+        with self.assertRaises(TypeError):
+            self.ectx.PolicyTicket(session, timeout, b"", b"", name, 42)
+
+        with self.assertRaises(TypeError):
+            self.ectx.PolicyTicket(
+                session, timeout, b"", b"", name, policy_ticket, session1="bar"
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.PolicyTicket(
+                session, timeout, b"", b"", name, policy_ticket, session2=56.7
+            )
+
+        with self.assertRaises(TypeError):
+            self.ectx.PolicyTicket(
+                session, timeout, b"", b"", name, policy_ticket, session3=object()
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -1271,6 +1271,33 @@ class TypesTest(unittest.TestCase):
         self.assertEqual(digests[1].hashAlg, TPM2_ALG.SHA256)
         self.assertEqual(bytes(digests[1].digest.sha256), sha256)
 
+    def test_TPML_DIGEST(self):
+
+        x = TPML_DIGEST([b"0123456789ABCDEF0123456789ABCDEF"])
+        self.assertEqual(len(x), 1)
+        self.assertEqual(x[0], b"0123456789ABCDEF0123456789ABCDEF")
+
+        x = TPML_DIGEST(
+            [
+                "0123456789ABCDEF0123456789ABCDEF",
+                b"12345678901234567890",
+                TPM2B_DIGEST(b"0123456"),
+            ]
+        )
+        self.assertEqual(len(x), 3)
+        self.assertEqual(x[0], b"0123456789ABCDEF0123456789ABCDEF")
+        self.assertEqual(x[1], b"12345678901234567890")
+        self.assertEqual(x[2], b"0123456")
+
+        with self.assertRaises(TypeError):
+            TPML_DIGEST([object(), object()])
+
+        with self.assertRaises(TypeError):
+            TPML_DIGEST(TPML_ALG_PROPERTY())
+
+        with self.assertRaises(TypeError):
+            TPML_PCR_SELECTION(TPML_AC_CAPABILITIES())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -2087,6 +2087,18 @@ class ESAPI:
         session3=ESYS_TR.NONE,
     ):
 
+        check_handle_type(policySession, "policySession")
+
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
+        timeout_cdata = get_cdata(timeout, TPM2B_TIMEOUT, "timeout")
+        cpHashA_cdata = get_cdata(cpHashA, TPM2B_DIGEST, "cpHashA")
+        policyRef_cdata = get_cdata(policyRef, TPM2B_NONCE, "policyRef")
+        authName_cdata = get_cdata(authName, TPM2B_NAME, "authName")
+        ticket_cdata = get_cdata(ticket, TPMT_TK_AUTH, "ticket")
+
         _chkrc(
             lib.Esys_PolicyTicket(
                 self.ctx,
@@ -2094,11 +2106,11 @@ class ESAPI:
                 session1,
                 session2,
                 session3,
-                timeout,
-                cpHashA,
-                policyRef,
-                authName,
-                ticket,
+                timeout_cdata,
+                cpHashA_cdata,
+                policyRef_cdata,
+                authName_cdata,
+                ticket_cdata,
             )
         )
 

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -2032,10 +2032,27 @@ class ESAPI:
         cpHashA,
         policyRef,
         expiration,
-        session1=ESYS_TR.NONE,
+        session1=ESYS_TR.PASSWORD,
         session2=ESYS_TR.NONE,
         session3=ESYS_TR.NONE,
     ):
+
+        check_handle_type(policySession, "policySession")
+
+        if not isinstance(expiration, int):
+            raise TypeError(
+                f"expected expiration to be type int, got {type(expiration)}"
+            )
+
+        check_friendly_int(authHandle, "authHandle", ESYS_TR)
+
+        check_handle_type(session1, "session1")
+        check_handle_type(session2, "session2")
+        check_handle_type(session3, "session3")
+
+        nonceTPM_cdata = get_cdata(nonceTPM, TPM2B_NONCE, "nonceTPM")
+        cpHashA_cdata = get_cdata(cpHashA, TPM2B_DIGEST, "cpHashA")
+        policyRef_cdata = get_cdata(policyRef, TPM2B_NONCE, "policyRef")
 
         timeout = ffi.new("TPM2B_TIMEOUT **")
         policyTicket = ffi.new("TPMT_TK_AUTH **")
@@ -2047,15 +2064,15 @@ class ESAPI:
                 session1,
                 session2,
                 session3,
-                nonceTPM,
-                cpHashA,
-                policyRef,
+                nonceTPM_cdata,
+                cpHashA_cdata,
+                policyRef_cdata,
                 expiration,
                 timeout,
                 policyTicket,
             )
         )
-        return (get_ptr(timeout), get_ptr(policyTicket))
+        return (TPM2B_TIMEOUT(get_ptr(timeout)), TPMT_TK_AUTH(get_ptr(policyTicket)))
 
     def PolicyTicket(
         self,

--- a/tpm2_pytss/utils.py
+++ b/tpm2_pytss/utils.py
@@ -109,10 +109,7 @@ def fixup_cdata_kwargs(this, _cdata, kwargs):
             # Its not a copy constructor, so it must be for a subfield,
             # so clear it from _cdata and call init
             unknown = _cdata
-            _cdata = None
-
-            if _cdata is None:
-                _cdata = ffi.new(f"{this.__class__.__name__} *")
+            _cdata = ffi.new(f"{this.__class__.__name__} *")
 
     # if it's unknown, find the field it's destined for. This is easy for TPML_
     # and TPM2B_ types because their is only one field.

--- a/tpm2_pytss/utils.py
+++ b/tpm2_pytss/utils.py
@@ -128,6 +128,16 @@ def fixup_cdata_kwargs(this, _cdata, kwargs):
                 f"Ambigous call, try using key {field_name} in parameters"
             )
 
+        if hasattr(unknown, "_cdata"):
+            a = cpointer_to_ctype(getattr(_cdata, field_name))
+            b = cpointer_to_ctype(unknown._cdata)
+            if a != b:
+                expected = fixup_classname(tipe)
+                got = fixup_classname(b)
+                raise TypeError(
+                    f"Expected initialization from type {expected}, got {got}"
+                )
+
         kwargs[field_name] = unknown
     elif len(kwargs) == 0:
         return (_cdata, {})


### PR DESCRIPTION
Also, make getitem of a TPML_* of TPM2B_SIMPLE objects return the bytes themselves over the wrapper.