### PR TITLE
types: add equal comparison method for TPM2B_SIMPLE_OBJECT

### DIFF
--- a/test/test_types.py
+++ b/test/test_types.py
@@ -1152,6 +1152,12 @@ class TypesTest(unittest.TestCase):
         b = bytes(dig)
         self.assertEqual(b, bob)
 
+        self.assertEqual(dig, bob)
+        self.assertNotEqual(dig, "pinchofbytes")
+
+        sdig = TPM2B_DIGEST(bob)
+        self.assertEqual(dig, sdig)
+
         with self.assertRaises(AttributeError):
             dig.size = 1
         with self.assertRaises(TypeError):

--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -1100,6 +1100,10 @@ class TPM2B_SIMPLE_OBJECT(TPM_OBJECT):
         b = self.__bytes__()
         return binascii.hexlify(b).decode()
 
+    def __eq__(self, value):
+        b = self.__bytes__()
+        return b == value
+
 
 class TPML_Iterator(object):
     def __init__(self, tpml):


### PR DESCRIPTION
Simply pass the comparison to an instance of bytes