### PR TITLE
crypto: add support for getting the public part from private keys

### DIFF
--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -189,6 +189,17 @@ Q18+gn3+xvLrQ0A=
 -----END PUBLIC KEY-----
 """
 
+ecc_encrypted_key = b"""
+-----BEGIN EC PRIVATE KEY-----
+Proc-Type: 4,ENCRYPTED
+DEK-Info: AES-256-CBC,3E4AA4A32C548CBB67F0D619538BE10B
+
+kjWZRRxDAcydDyuX3p3ZIaPqa2QtI7hA0neoLbSrbdJ0mNjN63epDJYAvQpIxYv9
+QuvaxyX7VW4guemvj/ZvHu3HuKr0TlvBqVtsGqIJbi3eCFvmll//qo1AG0mDAopL
+I8/rxsxXVofKhAfCeJ4gP6LOlr6uLQKdf0wYxzcYEZI=
+-----END EC PRIVATE KEY-----
+"""
+
 
 class CryptoTest(TSS2_EsapiTest):
     def test_public_from_pem_rsa(self):
@@ -644,3 +655,13 @@ class CryptoTest(TSS2_EsapiTest):
         self.assertEqual(pub.parameters.eccDetail.curveID, types.TPM2_ECC.NIST_P256)
         self.assertEqual(pub.unique.ecc.x, ecc_public_key_bytes[0:32])
         self.assertEqual(pub.unique.ecc.y, ecc_public_key_bytes[32:64])
+
+    def test_encrypted_key(self):
+        pub = TPMT_PUBLIC.from_pem(ecc_encrypted_key, password=b"mysecret")
+        self.assertEqual(pub.type, TPM2_ALG.ECC)
+
+        priv = TPMT_SENSITIVE.from_pem(ecc_encrypted_key, password=b"mysecret")
+        self.assertEqual(priv.sensitiveType, TPM2_ALG.ECC)
+
+        with self.assertRaises(ValueError):
+            TPMT_PUBLIC.from_pem(ecc_encrypted_key, password=b"passpass")

--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -610,3 +610,37 @@ class CryptoTest(TSS2_EsapiTest):
         self.assertEqual(
             pub.parameters.asymDetail.scheme.details.ecdsa.hashAlg, TPM2_ALG.SHA256
         )
+
+    def test_public_from_private(self):
+        pub = TPMT_PUBLIC.from_pem(rsa_private_key)
+        self.assertEqual(pub.type, types.TPM2_ALG.RSA)
+        self.assertEqual(pub.parameters.rsaDetail.keyBits, 2048)
+        self.assertEqual(pub.parameters.rsaDetail.exponent, 0)
+        self.assertEqual(pub.unique.rsa, rsa_public_key_bytes)
+
+        pub = TPMT_PUBLIC.from_pem(ecc_private_key)
+        self.assertEqual(pub.type, types.TPM2_ALG.ECC)
+        self.assertEqual(pub.parameters.eccDetail.curveID, types.TPM2_ECC.NIST_P256)
+        self.assertEqual(pub.unique.ecc.x, ecc_public_key_bytes[0:32])
+        self.assertEqual(pub.unique.ecc.y, ecc_public_key_bytes[32:64])
+
+    def test_public_from_private_der(self):
+        sl = rsa_private_key.strip().splitlines()
+        b64 = b"".join(sl[1:-1])
+        rsader = b64decode(b64)
+
+        pub = TPMT_PUBLIC.from_pem(rsader)
+        self.assertEqual(pub.type, types.TPM2_ALG.RSA)
+        self.assertEqual(pub.parameters.rsaDetail.keyBits, 2048)
+        self.assertEqual(pub.parameters.rsaDetail.exponent, 0)
+        self.assertEqual(pub.unique.rsa, rsa_public_key_bytes)
+
+        sl = ecc_private_key.strip().splitlines()
+        b64 = b"".join(sl[1:-1])
+        eccder = b64decode(b64)
+
+        pub = TPMT_PUBLIC.from_pem(eccder)
+        self.assertEqual(pub.type, types.TPM2_ALG.ECC)
+        self.assertEqual(pub.parameters.eccDetail.curveID, types.TPM2_ECC.NIST_P256)
+        self.assertEqual(pub.unique.ecc.x, ecc_public_key_bytes[0:32])
+        self.assertEqual(pub.unique.ecc.y, ecc_public_key_bytes[32:64])

--- a/tpm2_pytss/crypto.py
+++ b/tpm2_pytss/crypto.py
@@ -88,6 +88,11 @@ def key_from_encoding(data):
         key = cert.public_key()
     elif sdata.startswith(b"-----BEGIN PUBLIC KEY-----"):
         key = load_pem_public_key(data, backend=default_backend())
+    elif sdata.startswith(b"-----BEGIN RSA PRIVATE KEY-----") or sdata.startswith(
+        b"-----BEGIN EC PRIVATE KEY-----"
+    ):
+        pkey = load_pem_private_key(data, password=None, backend=default_backend())
+        key = pkey.public_key()
     elif sdata.startswith(b"ssh-") or sdata.startswith(b"ecdsa-sha2-"):
         key = load_ssh_public_key(data, backend=default_backend())
     else:
@@ -99,6 +104,11 @@ def key_from_encoding(data):
             pass
         try:
             key = load_der_public_key(data, backend=default_backend())
+        except ValueError:
+            pass
+        try:
+            pkey = load_der_private_key(data, password=None, backend=default_backend())
+            key = pkey.public_key()
         except ValueError:
             pass
 

--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -1670,6 +1670,7 @@ class TPMT_PUBLIC(TPM_OBJECT):
         ),
         symmetric=None,
         scheme=None,
+        password=None,
     ):
         """Decode the public part from standard key encodings.
 
@@ -1681,12 +1682,13 @@ class TPMT_PUBLIC(TPM_OBJECT):
             objectAttributes (int): The object attributes for the public area, default is (TPMA_OBJECT.DECRYPT | TPMA_OBJECT.SIGN_ENCRYPT | TPMA_OBJECT.USERWITHAUTH).
             symmetric (TPMT_SYM_DEF_OBJECT, optional): The symmetric definition to use for the public area, default is None.
             scheme (TPMT_ASYM_SCHEME, optional): The signing/key exchange scheme to use for the public area, default is None.
+            password (bytes, optional): The password used to decrypt the key, default is None.
 
         Returns:
             Returns a TPMT_PUBLIC instance.
         """
         p = cls()
-        public_from_encoding(data, p)
+        public_from_encoding(data, p, password=password)
         p.nameAlg = nameAlg
         p.objectAttributes = objectAttributes
         if symmetric is None:
@@ -1815,6 +1817,7 @@ class TPM2B_PUBLIC(TPM_OBJECT):
         ),
         symmetric=None,
         scheme=None,
+        password=None,
     ):
         """Decode the public part from standard key encodings.
 
@@ -1826,11 +1829,14 @@ class TPM2B_PUBLIC(TPM_OBJECT):
             objectAttributes (int): The object attributes for the public area, default is (TPMA_OBJECT.DECRYPT | TPMA_OBJECT.SIGN_ENCRYPT | TPMA_OBJECT.USERWITHAUTH).
             symmetric (TPMT_SYM_DEF_OBJECT, optional): The symmetric definition to use for the public area, default is None.
             scheme (TPMT_ASYM_SCHEME, optional): The signing/key exchange shceme to use for the public area, default is None.
+            password (bytes, optional): The password used to decrypt the key, default is None.
 
         Returns:
             Returns a TPM2B_PUBLIC instance.
         """
-        pa = TPMT_PUBLIC.from_pem(data, nameAlg, objectAttributes, symmetric, scheme)
+        pa = TPMT_PUBLIC.from_pem(
+            data, nameAlg, objectAttributes, symmetric, scheme, password
+        )
         p = cls(publicArea=pa)
         return p
 
@@ -1870,18 +1876,19 @@ class TPM2B_PUBLIC_KEY_RSA(TPM2B_SIMPLE_OBJECT):
 
 class TPM2B_SENSITIVE(TPM_OBJECT):
     @classmethod
-    def from_pem(cls, data):
+    def from_pem(cls, data, password=None):
         """Decode the private part from standard key encodings.
 
         Currently supports PEM, DER and SSH encoded private keys.
 
         Args:
             data (bytes): The encoded key as bytes.
+            password (bytes, optional): The password used to decrypt the key, default is None.
 
         Returns:
             Returns an instance of TPM2B_SENSITIVE.
         """
-        p = TPMT_SENSITIVE.from_pem(data)
+        p = TPMT_SENSITIVE.from_pem(data, password)
         return cls(sensitiveArea=p)
 
 
@@ -2292,19 +2299,20 @@ class TPMU_PUBLIC_ID(TPM_OBJECT):
 
 class TPMT_SENSITIVE(TPM_OBJECT):
     @classmethod
-    def from_pem(cls, data):
+    def from_pem(cls, data, password=None):
         """Decode the private part from standard key encodings.
 
         Currently supports PEM, DER and SSH encoded private keys.
 
         Args:
             data (bytes): The encoded key as bytes.
+            password (bytes, optional): The password used to decrypt the key, default is None.
 
         Returns:
             Returns an instance of TPMT_SENSITIVE.
         """
         p = cls()
-        private_from_encoding(data, p)
+        private_from_encoding(data, p, password)
         return p
 
 


### PR DESCRIPTION
Both RSA and ECC private keys can provide the public key so this enables from_pem in TPMT_PUBLIC/TPM2B_PUBLIC on private keys.