### PR TITLE
[RFC] types: add support for loading HMAC keys and seal data from bytes

### DIFF
--- a/tpm2_pytss/crypto.py
+++ b/tpm2_pytss/crypto.py
@@ -273,3 +273,21 @@ def symdef_to_crypt(symdef):
         raise ValueError(f"unsupported symmetric mode {symdef.mode.sym}")
     bits = symdef.keyBits.sym
     return (alg, mode, bits)
+
+
+def calculate_sym_unique(nameAlg, secret, seed):
+    dt = _get_digest(nameAlg)
+    if dt is None:
+        raise ValueError(f"unsupported digest algorithm: {nameAlg}")
+    d = hashes.Hash(dt(), backend=default_backend())
+    d.update(seed)
+    d.update(secret)
+    return d.finalize()
+
+
+def get_digest_size(alg):
+    dt = _get_digest(alg)
+    if dt is None:
+        raise ValueError(f"unsupported digest algorithm: {alg}")
+
+    return dt.digest_size


### PR DESCRIPTION
The reason for only having the keyedhash_from_secret method on TPMT_SENSITIVE / TPM2B_SENSITIVE is that the private and public parts are very interconnected.

I'm not 100% sure about this API, so some feedback would be appreciated.
Especially the seed value handling is a bit icky, I'm not sure that all zeros is a sane default or if it should be random.

After working out the API I'll do something similar for symmetric ciphers.