### PR TITLE
esapi: fix TCTI check in ESAPI init

### DIFF
--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -101,7 +101,7 @@ class ESAPI:
 
     def __init__(self, tcti: TCTI = None):
 
-        if not isinstance(tcti, (TCTI, None)):
+        if not isinstance(tcti, (TCTI, type(None))):
             raise TypeError(f"Expected tcti to be type TCTI or None, got {type(tcti)}")
 
         self._tcti = tcti


### PR DESCRIPTION
None is an instance, not a type

