### PR TITLE
Make FAPI ready for release

### DIFF
--- a/docs/fapi.rst
+++ b/docs/fapi.rst
@@ -1,4 +1,4 @@
-Fapi
+FAPI
 ====
 
 .. autoclass:: tpm2_pytss.FAPI

--- a/test/TSS2_BaseTest.py
+++ b/test/TSS2_BaseTest.py
@@ -87,7 +87,7 @@ class SwtpmSimulator(BaseTpmSimulator):
         if self._port is None:
             return None
 
-        return TctiLdr("swtpm", f"port={self._port}")
+        return TCTILdr("swtpm", f"port={self._port}")
 
 
 class IBMSimulator(BaseTpmSimulator):
@@ -128,7 +128,7 @@ class IBMSimulator(BaseTpmSimulator):
         if self._port is None:
             return None
 
-        return TctiLdr("mssim", f"port={self._port}")
+        return TCTILdr("mssim", f"port={self._port}")
 
 
 class TpmSimulator(object):

--- a/test/test_fapi.py
+++ b/test/test_fapi.py
@@ -1035,6 +1035,10 @@ class TestFapiRSA(Common):
         assert tpm_2b_private.size == 0xDE
         assert policy == ""
 
+    @pytest.mark.skipif(
+        not is_bug_fixed(fixed_in="3.2", backports=["2.4.7", "3.0.5", "3.1.1"]),
+        reason="tpm2-tss bug, see #2092",
+    )
     def test_encrypt_decrypt(self, decrypt_key):
         plaintext = b"Hello World!"
         ciphertext = self.fapi.encrypt(decrypt_key, plaintext)

--- a/test/test_fapi.py
+++ b/test/test_fapi.py
@@ -397,6 +397,30 @@ class Common:
         with pytest.raises(TSS2_Exception):
             self.fapi.create_seal(path=seal_path, data=seal_data)
 
+    def test_create_seal_random(self):
+        profile_name = self.fapi.config.profile_name
+        seal_path = f"/{profile_name}/HS/SRK/seal_{random_uid()}"
+        seal_len = 12
+        created = self.fapi.create_seal(path=seal_path, size=seal_len)
+        assert created is True
+        assert seal_path in self.fapi.list()
+
+        unseal_data = self.fapi.unseal(path=seal_path)
+        assert type(unseal_data) is bytes
+        assert len(unseal_data) == seal_len
+
+    def test_create_seal_both_data_and_size_fail(self):
+        profile_name = self.fapi.config.profile_name
+        seal_path = f"/{profile_name}/HS/SRK/seal_{random_uid()}"
+        with pytest.raises(ValueError):
+            self.fapi.create_seal(path=seal_path, data="Hello World", size=11)
+
+    def test_create_seal_neither_data_nor_size_fail(self):
+        profile_name = self.fapi.config.profile_name
+        seal_path = f"/{profile_name}/HS/SRK/seal_{random_uid()}"
+        with pytest.raises(ValueError):
+            self.fapi.create_seal(path=seal_path)
+
     def test_unseal(self, seal):
         seal_path, seal_data = seal
         unseal_data = self.fapi.unseal(path=seal_path)

--- a/test/test_fapi.py
+++ b/test/test_fapi.py
@@ -28,7 +28,7 @@ def simulator():
 
 @pytest.fixture(scope="class")
 def fapi_config_ecc(simulator):
-    with FapiConfig(
+    with FAPIConfig(
         temp_dirs=True,
         tcti=simulator.tcti_name_conf,
         ek_cert_less="yes",
@@ -39,7 +39,7 @@ def fapi_config_ecc(simulator):
 
 @pytest.fixture(scope="class")
 def fapi_config_rsa(simulator):
-    with FapiConfig(
+    with FAPIConfig(
         temp_dirs=True,
         tcti=simulator.tcti_name_conf,
         ek_cert_less="yes",

--- a/test/test_tcti.py
+++ b/test/test_tcti.py
@@ -70,7 +70,7 @@ class TestTCTI(TSS2_EsapiTest):
         self.assertIsInstance(self.tcti.conf, str)
 
         with self.assertRaises(TypeError):
-            TctiLdr(name=None, conf=1234)
+            TCTILdr(name=None, conf=1234)
 
         with self.assertRaises(TypeError):
-            TctiLdr(name=1234, conf=None)
+            TCTILdr(name=1234, conf=None)

--- a/tpm2_pytss/FAPI.py
+++ b/tpm2_pytss/FAPI.py
@@ -380,6 +380,11 @@ class FAPI:
         Returns:
             bytes: The ciphertext.
         """
+        check_bug_fixed(
+            fixed_in="3.2",
+            backports=["2.4.7", "3.0.5", "3.1.1"],
+            details="Faulty free of FAPI Encrypt might lead to Segmentation Fault. See https://github.com/tpm2-software/tpm2-tss/issues/2092",
+        )
         path = to_bytes_or_null(path)
         plaintext = to_bytes_or_null(plaintext)
         ciphertext = ffi.new("uint8_t **")

--- a/tpm2_pytss/FAPI.py
+++ b/tpm2_pytss/FAPI.py
@@ -105,8 +105,7 @@ class FapiConfig(contextlib.ExitStack):
     def __exit__(self, exc_type, exc_val, exc_tb):
         super().__exit__(exc_type, exc_val, exc_tb)
 
-        if self.config_env_backup is not None:
-            os.environ[FAPI_CONFIG_ENV] = self.config_env_backup
+        del os.environ[FAPI_CONFIG_ENV]
 
         if self.config_tmp_path is not None:
             os.unlink(self.config_tmp_path)

--- a/tpm2_pytss/FAPI.py
+++ b/tpm2_pytss/FAPI.py
@@ -421,6 +421,7 @@ class FAPI:
         type_: Optional[Union[bytes, str]] = None,
         policy_path: Optional[Union[bytes, str]] = None,
         auth_value: Optional[Union[bytes, str]] = None,
+        size: Optional[int] = None,
         exists_ok: bool = False,
     ) -> bool:
         """Create a Fapi sealed (= encrypted) object, that is data sealed a Fapi parent key. Oftentimes, the data is a digest.
@@ -431,6 +432,7 @@ class FAPI:
             type_ (bytes or str, optional): Comma separated list. Possible values: system, sign, decrypt, restricted, exportable, noda, 0x81000000. Defaults to None.
             policy_path (bytes or str, optional): The path to the policy which will be associated with the sealed object. Defaults to None.
             auth_value (bytes or str, optional): Password to protect the new sealed object. Defaults to None.
+            size (int, optional): If data is None, random bytes of length size are generated. Parameters data and size cannot be given at the same time. Defaults to None.
             exists_ok (bool, optional): Do not throw a TSS2_Exception if an object with the given path already exists. Defaults to False.
 
         Raises:
@@ -440,9 +442,12 @@ class FAPI:
             bool: True if the sealed object was created. False otherwise.
         """
         path = to_bytes_or_null(path)
+        if data is not None and size is not None:
+            raise ValueError("Parameters data and size cannot be given at same time.")
+        if data is None and size is None:
+            raise ValueError("Either parameter data or parameter size must be given.")
         if data is None:
-            # TODO if data is none, user should be able to give a size (of the random data)
-            data_len = 0
+            data_len = size
         else:
             data_len = len(data)
         data = to_bytes_or_null(data)

--- a/tpm2_pytss/FAPI.py
+++ b/tpm2_pytss/FAPI.py
@@ -25,7 +25,7 @@ FAPI_CONFIG_PATHS = [
 ]
 
 
-class FapiConfig(contextlib.ExitStack):
+class FAPIConfig(contextlib.ExitStack):
     """Context to create a temporary Fapi environment."""
 
     def __init__(self, config: Optional[dict] = None, temp_dirs: bool = True, **kwargs):
@@ -95,7 +95,7 @@ class FapiConfig(contextlib.ExitStack):
         fapi_conf_file.write(json.dumps(self.config))
         fapi_conf_file.close
         logger.debug(
-            f"Creating FapiConfig: {self.config_tmp_path}:\n{json.dumps(self.config, indent=4)}"
+            f"Creating FAPIConfig: {self.config_tmp_path}:\n{json.dumps(self.config, indent=4)}"
         )
 
         # Set fapi config env variable

--- a/tpm2_pytss/TCTILdr.py
+++ b/tpm2_pytss/TCTILdr.py
@@ -7,7 +7,7 @@ from .TCTI import TCTI
 from .utils import _chkrc
 
 
-class TctiLdr(TCTI):
+class TCTILdr(TCTI):
     def __init__(self, name=None, conf=None):
 
         self._ctx_pp = ffi.new("TSS2_TCTI_CONTEXT **")

--- a/tpm2_pytss/__init__.py
+++ b/tpm2_pytss/__init__.py
@@ -1,6 +1,6 @@
 from .ESAPI import ESAPI
 from .FAPI import *
-from .TctiLdr import *
+from .TCTILdr import *
 from .TCTI import TCTI
 from .types import *
 from .TSS2_Exception import TSS2_Exception

--- a/tpm2_pytss/utils.py
+++ b/tpm2_pytss/utils.py
@@ -17,11 +17,13 @@ __MOCK__ = "unittest.mock" in sys.modules
 
 
 def _chkrc(rc, acceptable=None):
-    if rc == lib.TPM2_RC_SUCCESS:
-        return
-    if acceptable is not None and (rc == acceptable or rc in acceptable):
-        return
-    raise TSS2_Exception(rc)
+    if acceptable is None:
+        acceptable = []
+    elif isinstance(acceptable, int):
+        acceptable = [acceptable]
+    acceptable += [lib.TPM2_RC_SUCCESS]
+    if rc not in acceptable:
+        raise TSS2_Exception(rc)
 
 
 def to_bytes_or_null(value, allow_null=True, encoding=None):


### PR DESCRIPTION
Changes:

* rename api files and classes to uppercase (pep8), as discussed in #54
* add optional size param to `FAPI.create_seal()`
* test Fapi against both RSA and ECC
* account for yet another bug in fapi: tpm2-software/tpm2-tss/issues/2092

Fixes #54

The tests are still brittle because they test against the system FAPI configs (and the defaults are assumed). This should not be a showstopper for the first release, though. Also, the documentation can be improved, for sure. However, to get this shipped, I'd say FAPI is ready for release. 

Edit: Fyi, I'm gonna be on leave the following week.