### PR TITLE
tsskey: set correct license

### DIFF
--- a/tpm2_pytss/tsskey.py
+++ b/tpm2_pytss/tsskey.py
@@ -1,5 +1,5 @@
 """
-SPDX-License-Identifier: BSD-3
+SPDX-License-Identifier: BSD-2
 """
 
 import warnings


### PR DESCRIPTION
Rest of the code is BSD-2 so tsskey.py should use the correct license.

fixes https://github.com/tpm2-software/tpm2-pytss/issues/222