### PR TITLE
types: add cdata information to __dir__

### DIFF
--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -1017,6 +1017,9 @@ class TPM_OBJECT(object):
             # recurse so we can get handling of setattr with Python wrapped data
             setattr(self, key, value)
 
+    def __dir__(self):
+        return object.__dir__(self) + dir(self._cdata)
+
     def marshal(self):
         """Marshal instance into bytes.
 


### PR DESCRIPTION
Since types are wrapping cdata attributes, we need to add those
attribute names to the __dir__ method of the wrapper object. This way
things introspecting the objects not only get the explicitly added
wrapper attributes (methods and data), but also the underlying data
attributes from cdata.

Fixes: #231

Signed-off-by: William Roberts <william.c.roberts@intel.com>