### PR TITLE
types: add string method for TPM_FRIENDLY_INT and TPM_FRIENDLY_INTLIST

### DIFF
--- a/test/test_types.py
+++ b/test/test_types.py
@@ -1460,6 +1460,29 @@ class TypesTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             ctx = TPMS_CONTEXT.from_tools(badversion)
 
+    def test_TPM_FRIENDLY_INT_str(self):
+        alg = TPM2_ALG(TPM2_ALG.ECC)
+        self.assertEqual(str(alg), "ecc")
+
+        badalg = TPM2_ALG(TPM2_ALG.LAST + 1)
+        self.assertEqual(str(badalg), str(TPM2_ALG.LAST + 1))
+
+    def test_TPM_FRIENDLY_INTLIST_str(self):
+        attrs = TPMA_OBJECT(
+            TPMA_OBJECT.DECRYPT | TPMA_OBJECT.NODA | TPMA_OBJECT.SIGN_ENCRYPT
+        )
+        self.assertEqual(str(attrs), "noda|decrypt|sign")
+
+        badattrs = TPMA_OBJECT(
+            TPMA_OBJECT.DECRYPT
+            | TPMA_OBJECT.NODA
+            | TPMA_OBJECT.SIGN_ENCRYPT
+            | 0x00090000
+        )
+        with self.assertRaises(ValueError) as e:
+            str(badattrs)
+        self.assertEqual(str(e.exception), "unnmatched values left: 0x80000")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -72,6 +72,12 @@ class TPM_FRIENDLY_INT(int):
 
         return f"{cls.__name__}.{m}"
 
+    def __str__(self):
+        for k, v in vars(self.__class__).items():
+            if int(self) == v:
+                return k.lower()
+        return str(int(self))
+
 
 class TPM_FRIENDLY_INTLIST(TPM_FRIENDLY_INT):
     @classmethod
@@ -99,6 +105,24 @@ class TPM_FRIENDLY_INTLIST(TPM_FRIENDLY_INT):
                     )
 
         return super().parse(intvalue)
+
+    def __str__(self):
+        cv = int(self)
+        ints = list()
+        for k, v in vars(self.__class__).items():
+            if k.startswith("_") or k.startswith("DEFAULT"):
+                continue
+            for fk, fv in self._FIXUP_MAP.items():
+                if k == fv:
+                    k = fk
+                    break
+            if not v & self:
+                continue
+            ints.append(k.lower())
+            cv = cv ^ v
+        if cv:
+            raise ValueError(f"unnmatched values left: 0x{cv:x}")
+        return "|".join(ints)
 
 
 class ESYS_TR(TPM_FRIENDLY_INT):


### PR DESCRIPTION
This will make types such as TPM2_ALG return tools-like strings when called with str(...)