### PR TITLE
docs/requirements: update babel

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 alabaster==0.7.12
-Babel==2.9.0
+Babel==2.9.1
 certifi==2020.12.5
 cffi==1.14.5
 chardet==4.0.0


### PR DESCRIPTION
Not really used in our code, but just on the CI to generate ReadTheDocs
output.

CVE-2021-42771
high severity
Vulnerable versions: < 2.9.1
Patched version: 2.9.1
Babel.Locale in Babel before 2.9.1 allows attackers to load arbitrary locale .dat files (containing serialized Python objects) via directory traversal, leading to code execution.

Signed-off-by: William Roberts <william.c.roberts@intel.com>