### PR TITLE
Revert "ci: pin to pip version 21.2.4"

### DIFF
--- a/.ci/install-deps.sh
+++ b/.ci/install-deps.sh
@@ -103,6 +103,12 @@ else
 fi
 
 #
+# Pip version 21.3 was broken with in-pace (-e) installs. Thus use something
+# after it as it was fixed in 21.3.1
+#
+python3 -m pip install --user --upgrade pip>21.3
+
+#
 # Install Python Development Dependencies
 #
 python3 -m pip install --user -e .[dev]


### PR DESCRIPTION
Fixed in version 2.3.1

This reverts commit 57428a8a3d738eff23240d8eaa499656e218d812.