### PR TITLE
Fix ESAPI Python types and comments, and many misspellings

### DIFF
--- a/.ci/install-deps.sh
+++ b/.ci/install-deps.sh
@@ -66,7 +66,7 @@ fi
 # Get a simulator
 #
 
-# Does our tcti suport the TCTI for swtpm, if so get the swtpm simulator
+# Does our tcti support the TCTI for swtpm? If so get the swtpm simulator
 if pkg-config --exists tss2-tcti-swtpm; then
 
   # libtpms

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,6 +1,6 @@
 # Cloning
 
-You need to clone recursive so that you will get the siwg interface files as a
+You need to clone recursive so that you will get the swig interface files as a
 submodule.
 
 ```console

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,8 +1,5 @@
 # Cloning
 
-You need to clone recursive so that you will get the swig interface files as a
-submodule.
-
 ```console
 $ git clone https://github.com/tpm2-software/tpm2-pytss
 ```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,7 +56,7 @@ ldconfig
 
 When you ran ``./configure`` for tpm2-tss if you didn't supply a prefix it usually
 defaults to ``/usr/local/``. When you ran ``make install`` it then installed the
-libraries under that path. Your pacakge manager usually installs libraries to
+libraries under that path. Your package manager usually installs libraries to
 ``/usr``. If you properly configure the ``ldconfig`` tool, it'll make the libraries
 you just installed available from within ``/usr/local`` (which means they won't
 clash with things your package manager installs). If you don't configure it then
@@ -104,7 +104,7 @@ Testing
 You need to have ``tpm_server`` installed in your path to run the tests.
 
 Download the latest version from https://sourceforge.net/projects/ibmswtpm2/files/
-and put it somewher in your ``$PATH``.
+and put it somewhere in your ``$PATH``.
 
 .. code-block:: console
 

--- a/scripts/prepare_headers.py
+++ b/scripts/prepare_headers.py
@@ -30,7 +30,7 @@ def remove_common_guards(s):
     s = re.sub("#ifdef __cplusplus\n}", "", s, flags=re.MULTILINE)
     s = re.sub("#include.*", "", s)
 
-    # Remove certain makros
+    # Remove certain macros
     s = re.sub("#define TSS2_API_VERSION.*", "", s)
     s = re.sub("#define TSS2_ABI_VERSION.*", "", s)
     s = re.sub("#define TSS2_RC_LAYER\(level\).*", "", s)

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -1386,7 +1386,7 @@ class ESAPI:
 
         Returns:
             A Tuple[TPM2B_PRIVATE, TPM2B_ENCRYPTED_SECRET] which is the object encrypted using
-            symmetric key derived from out_sym_seed and out_sym_seed whch is the Seed for a
+            symmetric key derived from out_sym_seed and out_sym_seed which is the Seed for a
             symmetric key protected by newParent asymmetric key respecitevely.
 
         C Function: Esys_Rewrap

--- a/tpm2_pytss/FAPI.py
+++ b/tpm2_pytss/FAPI.py
@@ -816,7 +816,7 @@ class FAPI:
         key_path: Union[bytes, str],
         policy_ref: Optional[Union[bytes, str]] = None,
     ):
-        """Specifiy the underlying policy/policies for a policy Authorize.
+        """Specify the underlying policy/policies for a policy Authorize.
 
         Args:
             policy_path (bytes or str): Path to the underlying policy.

--- a/tpm2_pytss/internal/crypto.py
+++ b/tpm2_pytss/internal/crypto.py
@@ -314,7 +314,7 @@ def verify_signature_rsa(signature, key, data):
         pad = padding.PSS(mgf=padding.MGF1(dt()), salt_length=dt.digest_size)
         mpad = padding.PSS(mgf=padding.MGF1(dt()), salt_length=padding.PSS.MAX_LENGTH)
     else:
-        raise ValueError(f"unsupported RSA signature algorihtm: {signature.sigAlg}")
+        raise ValueError(f"unsupported RSA signature algorithm: {signature.sigAlg}")
 
     sig = bytes(signature.signature.rsapss.sig)
     try:

--- a/tpm2_pytss/internal/utils.py
+++ b/tpm2_pytss/internal/utils.py
@@ -107,7 +107,7 @@ def _fixup_cdata_kwargs(this, _cdata, kwargs):
 
         if len(kwargs) != 0:
             raise RuntimeError(
-                f"Ambigous call, try using key {field_name} in parameters"
+                f"Ambiguous call, try using key {field_name} in parameters"
             )
 
         if hasattr(unknown, "_cdata"):

--- a/tpm2_pytss/tsskey.py
+++ b/tpm2_pytss/tsskey.py
@@ -133,7 +133,7 @@ class TSSPrivKey(object):
             private (TPM2B_PRIVATE): The private part of the TPM key.
             public (TPM2B_PUBLIC): The public part of the TPM key.
             empty_auth (bool): Defines if the authorization is a empty password, default is True.
-            parent (int): The parent of the key, either a persistant key handle or TPM2_RH_OWNER, default is TPM2_RH_OWNER.
+            parent (int): The parent of the key, either a persistent key handle or TPM2_RH_OWNER, default is TPM2_RH_OWNER.
         """
         self._private = private
         self._public = public

--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -574,7 +574,7 @@ class TPMT_PUBLIC(TPM_OBJECT):
             templ.objectAttributes & TPMA_OBJECT.DECRYPT
         )
 
-        # One could smarten this up to behave like tpm2-tools and trun down the attribute, but for now
+        # One could smarten this up to behave like tpm2-tools and turn down the attribute, but for now
         # error on bad attribute sets
         if is_both_set:
             raise ParserAttributeError(


### PR DESCRIPTION
In ESAPI:

- Use `Optional` or `Union[..., None]` where a variable can be `None`.
- Fix the description of some functions, which was probably copy-pasted from other ones.
- Use `ESYS_TR.OWNER` instead of `TPM2_RH_OWNER`, and also for `ENDORSEMENT` and `PLATFORM`
- Uniformize `ESYS_TR.PLATFORM+{PP}` notation (for "Physical Presence")

While at it, fix many other misspellings in other files.