### PR TITLE
add an unwrap function

### DIFF
--- a/test/test_makecred.py
+++ b/test/test_makecred.py
@@ -5,10 +5,12 @@ SPDX-License-Identifier: BSD-2
 import unittest
 
 from tpm2_pytss import *
-from tpm2_pytss.internal.crypto import _generate_seed
+from tpm2_pytss.internal.crypto import _generate_seed, private_to_key, public_to_key
 from tpm2_pytss.utils import *
 from .TSS2_BaseTest import TSS2_EsapiTest
 
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding
 
 rsa_private_key = b"""
 -----BEGIN RSA PRIVATE KEY-----
@@ -63,6 +65,42 @@ ecc_public_key = b"""-----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgO/tHxp/YOuP4wAV3w66C8JNiSHO
 KSAYtlNKSN4ZDI//wn0f7zBvUc7FqaRPA9LL6k6C1YfdOi/yvTB7Y4Tgaw==
 -----END PUBLIC KEY-----
+"""
+
+rsa_parent_key = b"""-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA0FeMzAfnskx8eZYICdqURfwRhcgAWHkanaDZQXAMsKyBwkov
+yso31lhQQpjghFv1hzxy9z9yvcE+7LnFWbTnhWH2PPYyR87iM6eaW9wGdaFLMX5R
+8xbYG1ZJYsBOfiS4LauEHDYaAsYL9uv/5K0Dw2d/LSxzbv+9+EC3AomICZsf7m1B
+BVQNvtWHaPBHH+19JGtGRg8KRBWRqnrzrx6WwpGtmHVNPJwOr5hz3FtOWj99STKc
+oow5EIR44lrzg4dDcpyi4vWiustdZJm2j2iHKMfGu37r/mMDPjKNxY1YZQS5B8s5
+lgxp76UBAfTm3mttyH1K79eoplgkA+qBglVqQQIDAQABAoIBAQCsA/0t4ED+x4Pm
+Z2dPq3bMqahWCqGuap79EncOPlNb87JXFiWLi5a6lMP/mHWXEs4P0GsjlPFJlqo7
+jc5RmLmnORCzmJo/C6Nb/r/FpE55BKkuvhsvV+cp+v4wWJL2N58RphE3sbucGqR6
+RLRMvETlKyinxZGxTdothFEV+TOmqT4c3YXUyxTZj74oh+ovl22xopehxz/g9QwK
+VdZa2bs9p5gxUeYlE3BQTt/YQAXDxPp2kTnWf8CjQ+f1YOlx+1OVJVaVPk5d3/8U
+7CK5ljZoB5y11AYT11cxlqwphlF3ePJYIuTQHRldCO2Z7fv2GFJnVqKH+eu2/4AT
+94RpHpyBAoGBAO1fOV0QL7ZQk0pJlY0yETrfZRkLcUM9lFzWnF8N/zfv4CcawZpw
+PvSU5tTSnF/aYJn94KSKeZ/CiIJog4metlHNIc6qZBVTvh3lOGndib9YjLQ0j/Ru
+gYITCMmffe74+RTD4yTmbCttoay3DzIX+rK9RMEg7SDRrHxmsWRoZzKpAoGBAOCx
+HfG+FiZgJdWkelOgSBWG+9tcNmKyV+1wLR0XDx+Ung/0IWfhov4im6sPKKmKOALk
+A2cKKkcByr57Y57oBS1oT8489G8rgR4hJlBZOU40N8HRLg+9FafFH5ObS29zUeis
+AP/wq2l8DOlWUfRN1W8+YzamyOdDIGdgtGn1tFHZAoGBAKjxQS6POqYTqwEQZjRc
+Eg9It/efQTmONm3tANZWa/Mv8uViEbENeoExCSknzMwb7O0s2BnDxNSD7AyEvjnQ
+kAqgaRNiCmFzfLhiUEhouIVLTLllP5/ElsAxM+vsbAENipnQ4XV92jb+jDcVAuew
+UWmtc6XQ/XSCRrUzkcXY2LohAoGAJiNqJcJSGClxwpWsfc1S7vR+g3lfcdk7u32y
+6qEjXATp32Nc2DkgZWqSabKlAEIJx9PUEAVVr7/KHhLrkeloF5EBGsyV4NjNjcOq
+sTCz3WZXoHpVCy7ZIiT/exp872nvmUK42LiNH9aCioiwWHttovg/9uLQbxChy2pK
+tUGTXeECgYBYh3LsYNuWHpi2tW+cO3V4XP1AGBqZy3SDKD/Uk1jZPjEamkZCRDl2
+9AGIGz0H+Ovfg8vzCgYj0E9KLlE63wjSsKajC+Z17+nwzvy9cFJJtqTq/7aR0niI
+DoDguNqFEpw/cs8Eccbh0K43ubpLXc7xKoLGe5CF1sxEOZpYnPbyoA==
+-----END RSA PRIVATE KEY-----
+"""
+
+ec_parent_key = b"""-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIODZrhXcbRQDOZUmzvYIWtU04ubMA7xTYnzsMs/LhwRUoAoGCCqGSM49
+AwEHoUQDQgAEojRWBjpOkP4pH2fM5hha7iJj4A9RfDcbJrGTd181UMoYvfM+8VuY
+Qa6C2sTmPHlvWopRgWslXt1JmxbBKwWf2Q==
+-----END EC PRIVATE KEY-----
 """
 
 
@@ -172,6 +210,228 @@ class MakeCredTest(TSS2_EsapiTest):
             duplicate,
             outsymseed,
             TPMT_SYM_DEF_OBJECT(algorithm=TPM2_ALG.NULL),
+        )
+
+    def test_unwrap_rsa_parent_rsa_child(self):
+
+        parent_priv = TPMT_SENSITIVE.from_pem(rsa_parent_key, password=None)
+        parent = TPM2B_PUBLIC.from_pem(
+            rsa_parent_key,
+            symmetric=TPMT_SYM_DEF_OBJECT(
+                algorithm=TPM2_ALG.AES,
+                keyBits=TPMU_SYM_KEY_BITS(aes=128),
+                mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
+            ),
+        )
+
+        public = TPM2B_PUBLIC.from_pem(rsa_public_key)
+        sensitive = TPM2B_SENSITIVE.from_pem(rsa_private_key)
+
+        enckey, duplicate, outsymseed = wrap(
+            parent.publicArea, public, sensitive, b"", None
+        )
+
+        unwrapped_sensitive = unwrap(
+            parent.publicArea, parent_priv, public, duplicate, outsymseed
+        )
+
+        self.assertEqual(sensitive.marshal(), unwrapped_sensitive.marshal())
+
+    def test_unwrap_rsa_parent_rsa_child_outerwrap(self):
+
+        symdef = TPMT_SYM_DEF_OBJECT(
+            algorithm=TPM2_ALG.AES,
+            keyBits=TPMU_SYM_KEY_BITS(aes=128),
+            mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
+        )
+
+        parent_priv = TPMT_SENSITIVE.from_pem(rsa_parent_key)
+        parent = TPM2B_PUBLIC.from_pem(rsa_parent_key, symmetric=symdef)
+
+        public = TPM2B_PUBLIC.from_pem(rsa_public_key)
+        sensitive = TPM2B_SENSITIVE.from_pem(rsa_private_key)
+
+        enckey, duplicate, outsymseed = wrap(
+            parent.publicArea, public, sensitive, b"\xA1" * 16, symdef
+        )
+
+        unwrapped_sensitive = unwrap(
+            parent.publicArea,
+            parent_priv,
+            public,
+            duplicate,
+            outsymseed,
+            b"\xA1" * 16,
+            symdef,
+        )
+
+        self.assertEqual(sensitive.marshal(), unwrapped_sensitive.marshal())
+
+    def test_unwrap_ec_parent_rsa_child(self):
+
+        parent_priv = TPMT_SENSITIVE.from_pem(ec_parent_key, password=None)
+        parent = TPM2B_PUBLIC.from_pem(
+            ec_parent_key,
+            symmetric=TPMT_SYM_DEF_OBJECT(
+                algorithm=TPM2_ALG.AES,
+                keyBits=TPMU_SYM_KEY_BITS(aes=128),
+                mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
+            ),
+        )
+
+        public = TPM2B_PUBLIC.from_pem(rsa_public_key)
+        sensitive = TPM2B_SENSITIVE.from_pem(rsa_private_key)
+
+        enckey, duplicate, outsymseed = wrap(
+            parent.publicArea, public, sensitive, b"", None
+        )
+
+        unwrapped_sensitive = unwrap(
+            parent.publicArea, parent_priv, public, duplicate, outsymseed
+        )
+
+        self.assertEqual(sensitive.marshal(), unwrapped_sensitive.marshal())
+
+    def test_unwrap_ec_parent_rsa_child_outerwrap(self):
+
+        symdef = TPMT_SYM_DEF_OBJECT(
+            algorithm=TPM2_ALG.AES,
+            keyBits=TPMU_SYM_KEY_BITS(aes=128),
+            mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
+        )
+
+        parent_priv = TPMT_SENSITIVE.from_pem(ec_parent_key, password=None)
+        parent = TPM2B_PUBLIC.from_pem(ec_parent_key, symmetric=symdef)
+
+        public = TPM2B_PUBLIC.from_pem(rsa_public_key)
+        sensitive = TPM2B_SENSITIVE.from_pem(rsa_private_key)
+
+        enckey, duplicate, outsymseed = wrap(
+            parent.publicArea, public, sensitive, b"\xA1" * 16, symdef
+        )
+
+        unwrapped_sensitive = unwrap(
+            parent.publicArea,
+            parent_priv,
+            public,
+            duplicate,
+            outsymseed,
+            b"\xA1" * 16,
+            symdef,
+        )
+
+        self.assertEqual(sensitive.marshal(), unwrapped_sensitive.marshal())
+
+    def test_tpm_export_rsa_child_rsa_parent_with_inner_key(self):
+
+        #
+        # Step 1 - Create a TPM object to duplicate
+        #
+        phandle = self.ectx.create_primary(None)[0]
+
+        # Create the child key, note we need to be able to enter the DUP role which requires
+        # a policy session.
+        session = self.ectx.start_auth_session(
+            tpm_key=ESYS_TR.NONE,
+            bind=ESYS_TR.NONE,
+            session_type=TPM2_SE.TRIAL,
+            symmetric=TPMT_SYM_DEF(
+                algorithm=TPM2_ALG.AES,
+                keyBits=TPMU_SYM_KEY_BITS(aes=128),
+                mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
+            ),
+            auth_hash=TPM2_ALG.SHA256,
+        )
+
+        self.ectx.policy_auth_value(session)
+        self.ectx.policy_command_code(session, TPM2_CC.Duplicate)
+        policy_digest = self.ectx.policy_get_digest(session)
+        self.ectx.flush_context(session)
+        session = None
+        in_pub = TPM2B_PUBLIC.parse(
+            "rsa2048:aes128cfb",
+            objectAttributes="userwithauth|restricted|decrypt|sensitivedataorigin",
+            authPolicy=policy_digest,
+        )
+        tpm_priv, tpm_pub = self.ectx.create(phandle, None, in_pub)[:2]
+        chandle = self.ectx.load(phandle, tpm_priv, tpm_pub)
+
+        #
+        # Step 2 - Duplicate it under a parent where you control the key. The parent MUST be a storage parent.
+        #
+        sym = TPMT_SYM_DEF_OBJECT(
+            algorithm=TPM2_ALG.AES,
+            keyBits=TPMU_SYM_KEY_BITS(aes=128),
+            mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
+        )
+
+        parent = TPM2B_PUBLIC.from_pem(
+            ec_parent_key,
+            objectAttributes=TPMA_OBJECT.RESTRICTED | TPMA_OBJECT.DECRYPT,
+            symmetric=sym,
+        )
+        new_phandle = self.ectx.load_external(None, parent)
+
+        session = self.ectx.start_auth_session(
+            tpm_key=ESYS_TR.NONE,
+            bind=ESYS_TR.NONE,
+            session_type=TPM2_SE.POLICY,
+            symmetric=TPMT_SYM_DEF(
+                algorithm=TPM2_ALG.AES,
+                keyBits=TPMU_SYM_KEY_BITS(aes=128),
+                mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
+            ),
+            auth_hash=TPM2_ALG.SHA256,
+        )
+
+        self.ectx.policy_auth_value(session)
+        self.ectx.policy_command_code(session, TPM2_CC.Duplicate)
+
+        encryptionKey = b"is sixteen bytes"
+
+        # this is wrap performed by the TPM
+        enckey, duplicate, outsymseed = self.ectx.duplicate(
+            chandle, new_phandle, encryptionKey, sym, session1=session
+        )
+
+        #
+        # Step 4 - unwrap with the new parent private key
+        #
+        parent_priv = TPMT_SENSITIVE.from_pem(ec_parent_key, password=None)
+
+        unwrapped_sensitive = unwrap(
+            parent.publicArea,
+            parent_priv,
+            tpm_pub,
+            duplicate,
+            outsymseed,
+            encryptionKey,
+            sym,
+        )
+
+        #
+        # Step 5, validate the key by signing with the private key and verifying with the
+        # public from create
+        #
+        priv_key = private_to_key(unwrapped_sensitive.sensitiveArea, tpm_pub.publicArea)
+
+        message = b"A message I want to sign"
+        signature = priv_key.sign(
+            message,
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH
+            ),
+            hashes.SHA256(),
+        )
+
+        pub_key = public_to_key(tpm_pub.publicArea)
+        pub_key.verify(
+            signature,
+            message,
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH
+            ),
+            hashes.SHA256(),
         )
 
 

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -40,6 +40,7 @@ DoDguNqFEpw/cs8Eccbh0K43ubpLXc7xKoLGe5CF1sxEOZpYnPbyoA==
 from cryptography.hazmat.primitives.serialization import (
     load_pem_private_key,
     load_der_private_key,
+    load_ssh_private_key,
 )
 
 
@@ -1601,6 +1602,36 @@ class TypesTest(unittest.TestCase):
 
         der = priv.to_der(pub.publicArea)
         load_der_private_key(der, password=None)
+
+    def test_TPMT_SENSITIVE_to_ssh(self):
+
+        priv = TPMT_SENSITIVE.from_pem(rsa_parent_key)
+        pub = TPM2B_PUBLIC.from_pem(
+            rsa_parent_key,
+            symmetric=TPMT_SYM_DEF_OBJECT(
+                algorithm=TPM2_ALG.AES,
+                keyBits=TPMU_SYM_KEY_BITS(aes=128),
+                mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
+            ),
+        )
+
+        sshpem = priv.to_ssh(pub.publicArea)
+        load_ssh_private_key(sshpem, password=None)
+
+    def test_TPM2B_SENSITIVE_to_ssh(self):
+
+        priv = TPM2B_SENSITIVE.from_pem(rsa_parent_key)
+        pub = TPM2B_PUBLIC.from_pem(
+            rsa_parent_key,
+            symmetric=TPMT_SYM_DEF_OBJECT(
+                algorithm=TPM2_ALG.AES,
+                keyBits=TPMU_SYM_KEY_BITS(aes=128),
+                mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
+            ),
+        )
+
+        sshpem = priv.to_ssh(pub.publicArea)
+        load_ssh_private_key(sshpem, password=None)
 
 
 if __name__ == "__main__":

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -37,7 +37,10 @@ DoDguNqFEpw/cs8Eccbh0K43ubpLXc7xKoLGe5CF1sxEOZpYnPbyoA==
 -----END RSA PRIVATE KEY-----
 """
 
-from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from cryptography.hazmat.primitives.serialization import (
+    load_pem_private_key,
+    load_der_private_key,
+)
 
 
 class TypesTest(unittest.TestCase):
@@ -1568,6 +1571,36 @@ class TypesTest(unittest.TestCase):
             load_pem_private_key(pem, password=None)
 
         load_pem_private_key(pem, password=b"foo")
+
+    def test_TPMT_SENSITIVE_to_der(self):
+
+        priv = TPMT_SENSITIVE.from_pem(rsa_parent_key)
+        pub = TPM2B_PUBLIC.from_pem(
+            rsa_parent_key,
+            symmetric=TPMT_SYM_DEF_OBJECT(
+                algorithm=TPM2_ALG.AES,
+                keyBits=TPMU_SYM_KEY_BITS(aes=128),
+                mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
+            ),
+        )
+
+        der = priv.to_der(pub.publicArea)
+        load_der_private_key(der, password=None)
+
+    def test_TPM2B_SENSITIVE_to_der(self):
+
+        priv = TPM2B_SENSITIVE.from_pem(rsa_parent_key)
+        pub = TPM2B_PUBLIC.from_pem(
+            rsa_parent_key,
+            symmetric=TPMT_SYM_DEF_OBJECT(
+                algorithm=TPM2_ALG.AES,
+                keyBits=TPMU_SYM_KEY_BITS(aes=128),
+                mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
+            ),
+        )
+
+        der = priv.to_der(pub.publicArea)
+        load_der_private_key(der, password=None)
 
 
 if __name__ == "__main__":

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -104,7 +104,7 @@ Qa6C2sTmPHlvWopRgWslXt1JmxbBKwWf2Q==
 """
 
 
-class MakeCredTest(TSS2_EsapiTest):
+class TestUtils(TSS2_EsapiTest):
     def test_generate_seed_rsa(self):
         insens = TPM2B_SENSITIVE_CREATE()
         _, public, _, _, _ = self.ectx.create_primary(insens)

--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -738,6 +738,7 @@ class TPMT_PUBLIC(TPM_OBJECT):
         alg="rsa",
         objectAttributes=TPMA_OBJECT.DEFAULT_TPM2_TOOLS_CREATE_ATTRS,
         nameAlg="sha256",
+        authPolicy=None,
     ):
 
         templ = TPMT_PUBLIC()
@@ -749,6 +750,9 @@ class TPMT_PUBLIC(TPM_OBJECT):
         if isinstance(objectAttributes, str):
             objectAttributes = TPMA_OBJECT.parse(objectAttributes)
         templ.objectAttributes = objectAttributes
+
+        if authPolicy is not None:
+            templ.authPolicy = authPolicy
 
         alg = alg.lower()
 
@@ -994,9 +998,10 @@ class TPM2B_PUBLIC(TPM_OBJECT):
         alg="rsa",
         objectAttributes=TPMA_OBJECT.DEFAULT_TPM2_TOOLS_CREATE_ATTRS,
         nameAlg="sha256",
+        authPolicy=None,
     ):
 
-        return cls(TPMT_PUBLIC.parse(alg, objectAttributes, nameAlg))
+        return cls(TPMT_PUBLIC.parse(alg, objectAttributes, nameAlg, authPolicy))
 
 
 class TPM2B_PUBLIC_KEY_RSA(TPM2B_SIMPLE_OBJECT):

--- a/tpm2_pytss/utils.py
+++ b/tpm2_pytss/utils.py
@@ -2,11 +2,15 @@ from .internal.crypto import (
     _kdfa,
     _get_digest,
     _symdef_to_crypt,
+    _secret_to_seed,
     _generate_seed,
+    _decrypt,
     _encrypt,
+    _check_hmac,
     _hmac,
 )
 from .types import *
+from cryptography.hazmat.primitives import constant_time as ct
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.backends import default_backend
 from typing import Optional, Tuple
@@ -127,3 +131,99 @@ def wrap(
     duplicate = TPM2B_PRIVATE(buffer=hmacdata + dupsens)
 
     return (enckeyout, duplicate, outsymseed)
+
+
+def unwrap(
+    newparentpub: TPMT_PUBLIC,
+    newparentpriv: TPMT_SENSITIVE,
+    public: TPM2B_PUBLIC,
+    duplicate: TPM2B_PRIVATE,
+    outsymseed: TPM2B_ENCRYPTED_SECRET,
+    symkey: Optional[bytes] = None,
+    symdef: Optional[TPMT_SYM_DEF_OBJECT] = None,
+) -> TPM2B_SENSITIVE:
+    """unwraps a key under a TPM key hierarchy. In essence, export key from TPM.
+
+    This is the inverse function to the wrap() routine. This is usually performed by the TPM when importing
+    objects, however, if an object is duplicated under a new parent where one has both the public and private
+    keys, the object can be unwrapped.
+
+    Args:
+        newparentpub (TPMT_PUBLIC): The public area of the parent the key was duplicated/wrapped under.
+        newparentpriv(TPMT_SENSITIVE): The private key of the parent the key was duplicated/wrapped under.
+        public (TPM2B_PUBLIC): The public area of the key to be unwrapped.
+        duplicate(TPM2B_PRIVATE): The private or wrapped key to be unwrapped.
+        outsymseed(TPM2B_ENCRYPTED_SECRET): The output symmetric seed from a wrap or duplicate call.
+        symkey (bytes or None): Symmetric key for inner encryption. Defaults to None. When None
+        and symdef is defined a key will be generated based on the key size for symdef.
+        symdef (TPMT_SYMDEF_OBJECT): Symmetric algorithm to be used for inner encryption, defaults to None.
+        If None no inner wrapping is performed, else this should be set to aes128CFB since that is what
+        the TPM supports. To set to aes128cfb, do:
+        TPMT_SYM_DEF(
+          algorithm=TPM2_ALG.AES,
+          keyBits=TPMU_SYM_KEY_BITS(sym=128),
+          mode=TPMU_SYM_MODE(sym=TPM2_ALG.CFB),
+        )
+
+    Returns:
+        A tuple of (TPM2B_DATA, TPM2B_PRIVATE, TPM2B_ENCRYPTED_SECRET) which is the encryption key, the
+        the wrapped duplicate and the encrypted seed.
+
+    Raises:
+        ValueError: If the public key type or symmetric algorithm are not supported
+    """
+    halg = _get_digest(newparentpub.nameAlg)
+
+    seed = _secret_to_seed(newparentpriv, newparentpub, b"DUPLICATE\x00", outsymseed)
+    hmackey = _kdfa(
+        newparentpub.nameAlg, seed, b"INTEGRITY", b"", b"", halg.digest_size * 8
+    )
+
+    buffer = bytes(duplicate)
+
+    hmacdata, offset = TPM2B_DIGEST.unmarshal(buffer)
+    outerhmac = bytes(hmacdata)
+
+    dupsens = buffer[offset:]
+    name = bytes(public.get_name())
+    _check_hmac(halg, hmackey, dupsens, name, outerhmac)
+
+    cipher, _, bits = _symdef_to_crypt(newparentpub.parameters.asymDetail.symmetric)
+    outerkey = _kdfa(newparentpub.nameAlg, seed, b"STORAGE", name, b"", bits)
+
+    sensb = _decrypt(cipher, outerkey, dupsens)
+
+    if symdef and symdef.algorithm != TPM2_ALG.NULL:
+        if not symkey:
+            raise RuntimeError(
+                "Expected symkey when symdef is not None or Tsymdef.algorithm is not TPM2_ALG.NULL"
+            )
+
+        cipher, mode, bits = _symdef_to_crypt(symdef)
+        halg = _get_digest(public.publicArea.nameAlg)
+
+        # unwrap the inner encryption which is the integrity + TPM2B_SENSITIVE
+        innerint_and_decsens = _decrypt(cipher, symkey, sensb)
+        innerint, offset = TPM2B_DIGEST.unmarshal(innerint_and_decsens)
+        innerint = bytes(innerint)
+        decsensb = innerint_and_decsens[offset:]
+
+        h = hashes.Hash(halg(), backend=default_backend())
+        h.update(decsensb)
+        h.update(name)
+        integrity = h.finalize()
+
+        if not ct.bytes_eq(integrity, innerint):
+            raise RuntimeError("Expected inner integrity to match")
+
+        decsens = decsensb
+    else:
+        decsens = sensb
+
+    s, l = TPM2B_SENSITIVE.unmarshal(decsens)
+    if len(decsens) != l:
+        raise RuntimeError(
+            f"Expected the sensitive buffer to be size {l}, got: {len(encdupsens)}"
+        )
+
+    return s

--- a/tpm2_pytss/utils.py
+++ b/tpm2_pytss/utils.py
@@ -64,14 +64,22 @@ def wrap(
 ) -> Tuple[TPM2B_DATA, TPM2B_PRIVATE, TPM2B_ENCRYPTED_SECRET]:
     """Wraps key under a TPM key hierarchy
 
+    A key is wrapped following the Duplication protections of the TPM Architecture specification.
+    The architecture specification is found in "Part 1: Architecture" at the following link:
+      https://trustedcomputinggroup.org/resource/tpm-library-specification/
+
+    At the time of this writing, spec 1.59 was most recent and it was under section 23.3,
+    titled "Duplication".
+
     Args:
         newparent (TPMT_PUBLIC): The public area of the parent
         public (TPM2B_PUBLIC): The public area of the key
         sensitive (TPM2B_SENSITIVE): The sensitive area of the key
         symkey (bytes or None): Symmetric key for inner encryption. Defaults to None. When None
         and symdef is defined a key will be generated based on the key size for symdef.
-        symdef (TPMT_SYMDEF_OBJECT): Symmetric algorithm to be used for inner encryption. This should
-        be set to aes128CFB since that is what the TPM supports:
+        symdef (TPMT_SYMDEF_OBJECT): Symmetric algorithm to be used for inner encryption, defaults to None.
+        If None no inner wrapping is performed, else this should be set to aes128CFB since that is what
+        the TPM supports. To set to aes128cfb, do:
         TPMT_SYM_DEF(
           algorithm=TPM2_ALG.AES,
           keyBits=TPMU_SYM_KEY_BITS(sym=128),


### PR DESCRIPTION
Add the inverse operation of wrap, unwrap, which essentially allows for
TPM key exportation given a key with proper attributes. By duplicating
the key to a parent where one controls or has access to the private key,
the returned TPM2B_PRIVATE from the TPM2_Duplicate command can be
unwrapped into the TPMT_SENSITIVE. From there, folks can furlough that
key if needed, or use it in their favorite crypto lib.
