### PR TITLE
types: add to_der and to_ssh to {TPM2B,TPMT}_public

### DIFF
--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -559,17 +559,17 @@ class CryptoTest(TSS2_EsapiTest):
     def test_topem_encodings(self):
         pub = TPM2B_PUBLIC.from_pem(ecc_public_key)
 
-        pem = pub.to_pem(encoding="PEM")
+        pem = pub.to_pem()
         self.assertTrue(pem.startswith(b"-----BEGIN PUBLIC KEY-----"))
 
-        der = pub.to_pem(encoding="der")
+        der = pub.to_der()
         self.assertTrue(der.startswith(b"0Y0\x13\x06\x07"))
 
-        ssh = pub.to_pem(encoding="ssh")
+        ssh = pub.to_ssh()
         self.assertTrue(ssh.startswith(b"ecdsa-sha2-nistp256"))
 
         with self.assertRaises(ValueError) as e:
-            pub.to_pem(encoding="madeup")
+            crypto._public_to_pem(pub.publicArea, encoding="madeup")
         self.assertEqual(str(e.exception), "unsupported encoding: madeup")
 
     def test_rsa_exponent(self):

--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -832,16 +832,32 @@ class TPMT_PUBLIC(TPM_OBJECT):
             p.parameters.eccDetail.kdf.scheme = TPM2_ALG.NULL
         return p
 
-    def to_pem(self, encoding="pem"):
-        """Encode the public key in standard format.
-
-        Args:
-            encoding (str, optional): The encoding format, one of "pem", "der" or "ssh".
+    def to_pem(self):
+        """Encode the public key as PEM encoded ASN.1.
 
         Returns:
-            Returns the encoded key as bytes.
+            Returns the PEM encoded key as bytes.
         """
-        return _public_to_pem(self, encoding)
+
+        return _public_to_pem(self, "pem")
+
+    def to_der(self):
+        """Encode the public key as DER encoded ASN.1.
+
+        Returns:
+            Returns the DER encoded key as bytes.
+        """
+
+        return _public_to_pem(self, "der")
+
+    def to_ssh(self):
+        """Encode the public key in OpenSSH format
+
+        Returns:
+            Returns the OpenSSH encoded key as bytes.
+        """
+
+        return _public_to_pem(self, "ssh")
 
     def get_name(self):
         """Get the TPM name of the public area.
@@ -969,16 +985,32 @@ class TPM2B_PUBLIC(TPM_OBJECT):
         p = cls(publicArea=pa)
         return p
 
-    def to_pem(self, encoding="pem"):
-        """Encode the public key in standard format.
-
-        Args:
-            encoding (str, optional): The encoding format, one of "pem", "der" or "ssh".
+    def to_pem(self):
+        """Encode the public key as PEM encoded ASN.1.
 
         Returns:
-            Returns the encoded key as bytes.
+            Returns the PEM encoded key as bytes.
         """
-        return self.publicArea.to_pem(encoding)
+
+        return self.publicArea.to_pem()
+
+    def to_der(self):
+        """Encode the public key as DER encoded ASN.1.
+
+        Returns:
+            Returns the DER encoded key as bytes.
+        """
+
+        return self.publicArea.to_der()
+
+    def to_ssh(self):
+        """Encode the public key in OpenSSH format
+
+        Returns:
+            Returns the OpenSSH encoded key as bytes.
+        """
+
+        return self.publicArea.to_ssh()
 
     def get_name(self):
         """Get the TPM name of the public area.


### PR DESCRIPTION
With this both _SENSTIVE and _PUBLIC will have the same methods.

Fixes https://github.com/tpm2-software/tpm2-pytss/issues/267