### PR TITLE
Preprocessor fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,9 @@ class type_generator(build_ext):
             raise RuntimeError(
                 f"unable to find tss2_tpm2_types.h in {pk['include_dirs']}"
             )
-        pdata = preprocess_file(header_path)
+        pdata = preprocess_file(
+            header_path, cpp_args=["-D__extension__=", "-D__attribute__(x)="]
+        )
         parser = c_parser.CParser()
         ast = parser.parse(pdata, "tss2_tpm2_types.h")
         tm = self.get_types(ast)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 from setuptools.command.build_ext import build_ext
 from pkgconfig import pkgconfig
 from pycparser import c_parser, preprocess_file
-from pycparser.c_ast import Typedef, TypeDecl, IdentifierType, Struct, ArrayDecl
+from pycparser.c_ast import Typedef, TypeDecl, IdentifierType, Struct, ArrayDecl, Union
 from textwrap import dedent
 
 # workaround bug https://github.com/pypa/pip/issues/7953
@@ -114,11 +114,11 @@ class type_generator(build_ext):
         return fields
 
     def get_first_struct(self, v):
-        if isinstance(v, Struct):
+        if isinstance(v, (Struct, Union)):
             return v
         while hasattr(v, "type"):
             v = v.type
-            if isinstance(v, Struct):
+            if isinstance(v, (Struct, Union)):
                 return v
         return None
 


### PR DESCRIPTION
Fixes the type mapper when doing 32 bit (glibc) builds and add supports for unions in the type mapper (a good example for needing that is  TPMU_SYM_KEY_BITS)