### PR TITLE
constants/types: update docs and exceptions

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,10 +5,10 @@ The API documentation for the tpm2-pytss project.
 
 .. toctree::
 
-    constants
-    types
-    esys
-    fapi
-    utils
-    tsskey
-    tcti
+    TPM Constants <constants>
+    TPM Types <types>
+    TPM Command Transmission Interface (TCTI) <tcti>
+    Enhanced System API (ESAPI) <esys>
+    Feature API (FAPI) <fapi>
+    Utility Routines <utils>
+    TSS PEM Key (OpenSSL) <tsskey>

--- a/docs/constants.rst
+++ b/docs/constants.rst
@@ -4,3 +4,5 @@ Constants
 .. automodule:: tpm2_pytss.constants
    :members:
    :undoc-members:
+   :inherited-members: int
+   :special-members: __str__

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -231,7 +231,7 @@ class TypesTest(unittest.TestCase):
 
     def test_TPMS_PCR_SELECTION_parse_only_colon(self):
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPMS_PCR_SELECTION.parse(":")
 
     def test_TPMS_PCR_SELECTION_parse_only_bank_and_colon(self):
@@ -336,13 +336,13 @@ class TypesTest(unittest.TestCase):
         self.assertEqual(TPM2_ALG.parse("ECDH"), TPM2_ALG.ECDH)
         self.assertEqual(TPM2_ALG.parse("SHA3_512"), TPM2_ALG.SHA3_512)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPM2_ALG.parse("")
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             TPM2_ALG.parse(None)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPM2_ALG.parse("foo")
 
     def test_TPM_FRIENDLY_INT_bad_to_string(self):
@@ -359,13 +359,13 @@ class TypesTest(unittest.TestCase):
 
         self.assertEqual(ESYS_TR.to_string(ESYS_TR.OWNER), "ESYS_TR.OWNER")
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             ESYS_TR.parse("")
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             ESYS_TR.parse(None)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             ESYS_TR.parse("foo"), TPM2_ALG.SHA512
 
     def test_TPM2_ECC(self):
@@ -374,13 +374,13 @@ class TypesTest(unittest.TestCase):
         self.assertEqual(TPM2_ECC.parse("BN_P256"), TPM2_ECC.BN_P256)
         self.assertEqual(TPM2_ECC.parse("sm2_P256"), TPM2_ECC.SM2_P256)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPM2_ECC.parse("")
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             TPM2_ECC.parse(None)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPM2_ECC.parse("foo")
 
     def test_TPM2_CC(self):
@@ -389,13 +389,13 @@ class TypesTest(unittest.TestCase):
         self.assertEqual(TPM2_CC.parse("Certify"), TPM2_CC.Certify)
         self.assertEqual(TPM2_CC.parse("UnSEAL"), TPM2_CC.Unseal)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPM2_CC.parse("")
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             TPM2_CC.parse(None)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPM2_CC.parse("foo")
 
     def test_TPMA_OBJECT(self):
@@ -423,13 +423,13 @@ class TypesTest(unittest.TestCase):
             ),
         )
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPMA_OBJECT.parse("")
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             TPMA_OBJECT.parse(None)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPMA_OBJECT.parse("foo")
 
     def test_TPMA_NV(self):
@@ -446,13 +446,13 @@ class TypesTest(unittest.TestCase):
         self.assertEqual(TPMA_NV.parse("NodA"), TPMA_NV.NO_DA)
         self.assertEqual(TPMA_NV.parse("NODA"), TPMA_NV.NO_DA)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPMA_NV.parse("")
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             TPMA_NV.parse(None)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPMA_NV.parse("foo")
 
     def test_TPM2_SPEC(self):
@@ -460,13 +460,13 @@ class TypesTest(unittest.TestCase):
         self.assertEqual(TPM2_SPEC.parse("Level"), TPM2_SPEC.LEVEL)
         self.assertEqual(TPM2_SPEC.parse("DAY_of_YEAR"), TPM2_SPEC.DAY_OF_YEAR)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPM2_SPEC.parse("")
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             TPM2_SPEC.parse(None)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPM2_SPEC.parse("foo")
 
     def test_TPM2_GENERATED_VALUE(self):
@@ -474,13 +474,13 @@ class TypesTest(unittest.TestCase):
             TPM2_GENERATED_VALUE.parse("value"), TPM2_GENERATED_VALUE.VALUE
         )
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPM2_GENERATED_VALUE.parse("")
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             TPM2_GENERATED_VALUE.parse(None)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPM2_GENERATED_VALUE.parse("foo")
 
     def test_TPM2_RC(self):
@@ -488,13 +488,13 @@ class TypesTest(unittest.TestCase):
         self.assertEqual(TPM2_RC.parse("HMAC"), TPM2_RC.HMAC)
         self.assertEqual(TPM2_RC.parse("NO_RESULT"), TPM2_RC.NO_RESULT)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPM2_RC.parse("")
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             TPM2_RC.parse(None)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPM2_RC.parse("foo")
 
     def test_TPM2_EO(self):
@@ -502,13 +502,13 @@ class TypesTest(unittest.TestCase):
         self.assertEqual(TPM2_EO.parse("unsigned_GT"), TPM2_EO.UNSIGNED_GT)
         self.assertEqual(TPM2_EO.parse("BITCLEAR"), TPM2_EO.BITCLEAR)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPM2_EO.parse("")
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             TPM2_EO.parse(None)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPM2_EO.parse("foo")
 
     def test_TPM2_ST(self):
@@ -516,26 +516,26 @@ class TypesTest(unittest.TestCase):
         self.assertEqual(TPM2_ST.parse("AUTH_SECRET"), TPM2_ST.AUTH_SECRET)
         self.assertEqual(TPM2_ST.parse("fu_manifest"), TPM2_ST.FU_MANIFEST)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPM2_ST.parse("")
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             TPM2_ST.parse(None)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPM2_ST.parse("foo")
 
     def test_TPM2_SU(self):
         self.assertEqual(TPM2_SU.parse("clear"), TPM2_SU.CLEAR)
         self.assertEqual(TPM2_SU.parse("State"), TPM2_SU.STATE)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPM2_SU.parse("")
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             TPM2_SU.parse(None)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPM2_SU.parse("foo")
 
     def test_TPM2_SE(self):
@@ -543,13 +543,13 @@ class TypesTest(unittest.TestCase):
         self.assertEqual(TPM2_SE.parse("TRiaL"), TPM2_SE.TRIAL)
         self.assertEqual(TPM2_SE.parse("POLICY"), TPM2_SE.POLICY)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPM2_SE.parse("")
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             TPM2_SE.parse(None)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPM2_SE.parse("foo")
 
     def test_TPM2_PT(self):
@@ -557,13 +557,13 @@ class TypesTest(unittest.TestCase):
         self.assertEqual(TPM2_PT.parse("GrouP"), TPM2_PT.GROUP)
         self.assertEqual(TPM2_PT.parse("FIXED"), TPM2_PT.FIXED)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPM2_PT.parse("")
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             TPM2_PT.parse(None)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPM2_PT.parse("foo")
 
     def test_TPM2B_PUBLIC_specified_parts(self):
@@ -775,47 +775,29 @@ class TypesTest(unittest.TestCase):
         self.assertEqual(templ.parameters.rsaDetail.symmetric.algorithm, TPM2_ALG.AES)
 
     def test_TPMT_PUBLIC_parse_bad_params(self):
-        with self.assertRaises(RuntimeError) as e:
+        message = "Expected keybits for RSA to be one of ['1024', '2048', '3072', '4096'], got:\"512\""
+        with self.assertRaises(ValueError, msg=message) as e:
             TPMT_PUBLIC.parse(alg="rsa512")
-        self.assertEqual(
-            str(e.exception),
-            "Expected keybits for RSA to be one of ['1024', '2048', '3072', '4096'], got:\"512\"",
-        )
 
-        with self.assertRaises(RuntimeError) as e:
+        message = "Expected bits to be one of ['128', '192', '256'], got: \"512\""
+        with self.assertRaises(ValueError, msg=message) as e:
             TPMT_PUBLIC.parse(alg="rsa2048:aes512")
-        self.assertEqual(
-            str(e.exception),
-            "Expected bits to be one of ['128', '192', '256'], got: \"512\"",
-        )
 
-        with self.assertRaises(RuntimeError) as e:
+        message = "Expected mode to be one of ['cfb', 'cbc', 'ofb', 'ctr', 'ecb'], got: \"yyy\""
+        with self.assertRaises(ValueError, msg=message) as e:
             TPMT_PUBLIC.parse(alg="rsa2048:aes256yyy")
-        self.assertEqual(
-            str(e.exception),
-            "Expected mode to be one of ['cfb', 'cbc', 'ofb', 'ctr', 'ecb'], got: \"yyy\"",
-        )
 
-        with self.assertRaises(RuntimeError) as e:
+        message = "Expected object prefix to be one of ('rsa', 'ecc', 'aes', 'camellia', 'xor', 'hmac', 'keyedhash'), got: \"unsupported\""
+        with self.assertRaises(ValueError, msg=message) as e:
             TPMT_PUBLIC.parse("unsupported")
-        self.assertEqual(
-            str(e.exception),
-            "Expected object prefix to be one of ('rsa', 'ecc', 'aes', 'camellia', 'xor', 'hmac', 'keyedhash'), got: \"unsupported\"",
-        )
 
-        with self.assertRaises(RuntimeError) as e:
+        message = 'Expected symmetric detail to be null or start with one of aes, camellia, got: "hmac"'
+        with self.assertRaises(ValueError, msg=message) as e:
             TPMT_PUBLIC.parse("rsa2048:hmac")
-        self.assertEqual(
-            str(e.exception),
-            'Expected symmetric detail to be null or start with one of aes, camellia, got: "hmac"',
-        )
 
-        with self.assertRaises(RuntimeError) as e:
+        message = 'Keyedhash objects cannot have asym detail, got: "aes128"'
+        with self.assertRaises(ValueError, msg=message) as e:
             TPMT_PUBLIC.parse("hmac:aes128")
-        self.assertEqual(
-            str(e.exception),
-            'Keyedhash objects cannot have asym detail, got: "aes128"',
-        )
 
     def test_TPMT_PUBLIC_parse_ecc_ecdaa4_sha256(self):
 
@@ -1017,7 +999,7 @@ class TypesTest(unittest.TestCase):
         self.assertEqual(templ.parameters.keyedHashDetail.scheme.scheme, TPM2_ALG.NULL)
 
         # should fail, cannot have additional specifiers
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             templ = TPMT_PUBLIC.parse(alg="keyedhash:sha512")
 
     def test_TPMT_PUBLIC_parse_hmac(self):
@@ -1135,13 +1117,13 @@ class TypesTest(unittest.TestCase):
 
     def test_TPML_ALG_parse_bad(self):
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPML_ALG.parse("not,real,alg")
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPML_ALG.parse("jfghsjhdgfdhg")
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             TPML_ALG.parse("aes,rsa,foo")
 
     def test_TPML_ALG_setitem_single(self):

--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -513,7 +513,7 @@ class TPMT_PUBLIC(TPM_OBJECT):
 
         expected = ["1024", "2048", "3072", "4096"]
         if objstr not in expected:
-            raise RuntimeError(
+            raise ValueError(
                 f'Expected keybits for RSA to be one of {expected}, got:"{objstr}"'
             )
 
@@ -545,7 +545,7 @@ class TPMT_PUBLIC(TPM_OBJECT):
         bits = objstr[:3]
         expected = ["128", "192", "256"]
         if bits not in expected:
-            raise RuntimeError(f'Expected bits to be one of {expected}, got: "{bits}"')
+            raise ValueError(f'Expected bits to be one of {expected}, got: "{bits}"')
 
         bits = int(bits)
 
@@ -556,7 +556,7 @@ class TPMT_PUBLIC(TPM_OBJECT):
         else:
             expected = ["cfb", "cbc", "ofb", "ctr", "ecb"]
             if objstr not in expected:
-                raise RuntimeError(
+                raise ValueError(
                     f'Expected mode to be one of {expected}, got: "{objstr}"'
                 )
             mode = objstr
@@ -658,7 +658,7 @@ class TPMT_PUBLIC(TPM_OBJECT):
             halg = scheme[len("oaep") + 1 :]
         else:
             templ.parameters.asymDetail.scheme.scheme = TPM2_ALG.NULL
-            raise RuntimeError(
+            raise ValueError(
                 f'Expected RSA scheme null or rsapss or prefix of rsapss, rsassa, got "{scheme}"'
             )
 
@@ -698,7 +698,7 @@ class TPMT_PUBLIC(TPM_OBJECT):
             templ.parameters.eccDetail.scheme.scheme = TPM2_ALG.NULL
         else:
             templ.parameters.asymDetail.scheme.scheme = TPM2_ALG.NULL
-            raise RuntimeError(
+            raise ValueError(
                 f'Expected EC scheme null or prefix of oaep, ecdsa, ecdh, scshnorr, ecdaa, got "{scheme}"'
             )
 
@@ -726,7 +726,7 @@ class TPMT_PUBLIC(TPM_OBJECT):
                 TPM2_ALG.KDF1_SP800_108
             )
         else:
-            raise RuntimeError(
+            raise ValueError(
                 f'Expected one of HMAC or XOR, got: "{templ.parameters.keyedHashDetail.scheme.scheme}"'
             )
 
@@ -749,13 +749,13 @@ class TPMT_PUBLIC(TPM_OBJECT):
 
         if templ.type == TPM2_ALG.KEYEDHASH:
             if detail is not None:
-                raise RuntimeError(
+                raise ValueError(
                     f'Keyedhash objects cannot have asym detail, got: "{detail}"'
                 )
             return
 
         if templ.type != TPM2_ALG.RSA and templ.type != TPM2_ALG.ECC:
-            raise RuntimeError(
+            raise ValueError(
                 f'Expected only RSA and ECC objects to have asymdetail, got: "{templ.type}"'
             )
 
@@ -776,7 +776,7 @@ class TPMT_PUBLIC(TPM_OBJECT):
             templ.parameters.symDetail.sym.algorithm = TPM2_ALG.CAMELLIA
             detail = detail[8:]
         else:
-            raise RuntimeError(
+            raise ValueError(
                 f'Expected symmetric detail to be null or start with one of aes, camellia, got: "{detail}"'
             )
 
@@ -792,7 +792,8 @@ class TPMT_PUBLIC(TPM_OBJECT):
         nameAlg="sha256",
         authPolicy=None,
     ):
-
+        """
+        """
         templ = TPMT_PUBLIC()
 
         if isinstance(nameAlg, str):
@@ -823,13 +824,13 @@ class TPMT_PUBLIC(TPM_OBJECT):
                 objstr[len(prefix) :], templ
             )
         else:
-            raise RuntimeError(
+            raise ValueError(
                 f'Expected object prefix to be one of {expected}, got: "{objstr}"'
             )
 
         if not keep_processing:
             if scheme:
-                raise RuntimeError(
+                raise ValueError(
                     f'{prefix} objects cannot have additional specifiers, got: "{scheme}"'
                 )
             return templ
@@ -837,7 +838,7 @@ class TPMT_PUBLIC(TPM_OBJECT):
         # at this point we either have scheme as a scheme or an asym detail
         try:
             TPMT_PUBLIC._handle_scheme(scheme, templ)
-        except RuntimeError as e:
+        except ValueError as e:
             # nope try it as asymdetail
             symdetail = scheme
 


### PR DESCRIPTION
Update the exceptions that the various parse routines can throw to use
ValueError and TypeError over the less specific RuntimeError and
document the inherited interfaces.

This is was kept as one commit since detangling it was more of a
headache than what it is worth (we wouldn't try and revert part of it).

Signed-off-by: William Roberts <william.c.roberts@intel.com>