### PR TITLE
Fix misspellings in Python code

### DIFF
--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -6864,7 +6864,7 @@ class ESAPI:
                 ESYS_TR.ENDORSEMENT: TPM2_RH.ENDORSEMENT,
             }
             if hierarchy not in fixup_map:
-                raise RunTimeError(
+                raise RuntimeError(
                     "Expected hierarchy to be one of ESYS_TR.NULL, ESYS_TR.PLATFORM, ESYS_TR.OWNER, ESYS_TR.ENDORSMENT"
                 )
 

--- a/tpm2_pytss/internal/crypto.py
+++ b/tpm2_pytss/internal/crypto.py
@@ -285,7 +285,9 @@ def private_to_key(private: "types.TPMT_SENSITIVE", public: "types.TPMT_PUBLIC")
 
         curve = _get_curve(public.parameters.eccDetail.curveID)
         if curve is None:
-            raise ValueError(f"unsupported curve: {obj.parameters.eccDetail.curveID}")
+            raise ValueError(
+                f"unsupported curve: {public.parameters.eccDetail.curveID}"
+            )
 
         p = int.from_bytes(bytes(private.sensitive.ecc), byteorder="big")
         x = int.from_bytes(bytes(public.unique.ecc.x), byteorder="big")

--- a/tpm2_pytss/utils.py
+++ b/tpm2_pytss/utils.py
@@ -222,7 +222,7 @@ def unwrap(
     s, l = TPM2B_SENSITIVE.unmarshal(decsens)
     if len(decsens) != l:
         raise RuntimeError(
-            f"Expected the sensitive buffer to be size {l}, got: {len(encdupsens)}"
+            f"Expected the sensitive buffer to be size {l}, got: {len(decsens)}"
         )
 
     return s


### PR DESCRIPTION
Hello,
While seeing how to make the code compliant with `mypy --strict`, I stumbled upon misspellings in the code which were reported as:

```text
tpm2_pytss/ESAPI.py:6867: error: Name 'RunTimeError' is not defined

tpm2_pytss/utils.py:225: error: Name 'encdupsens' is not defined
```

This Pull Request fixes these misspellings.

EDIT: added a 3rd occurrence, found with `tpm2_pytss/internal/crypto.py:288: error: Name 'obj' is not defined`