### PR TITLE
types: ensure deconstructor order

### DIFF
--- a/tpm2_pytss/internal/utils.py
+++ b/tpm2_pytss/internal/utils.py
@@ -125,10 +125,24 @@ def _fixup_cdata_kwargs(this, _cdata, kwargs):
     return (_cdata, kwargs)
 
 
-def _convert_to_python_native(global_map, data):
+def _ref_parent(data, parent):
+    tipe = ffi.typeof(parent)
+    if tipe.kind != "pointer":
+        return data
+
+    def deconstructor(ptr):
+        parent
+
+    return ffi.gc(data, deconstructor)
+
+
+def _convert_to_python_native(global_map, data, parent=None):
 
     if not isinstance(data, ffi.CData):
         return data
+
+    if parent is not None:
+        data = _ref_parent(data, parent)
 
     tipe = ffi.typeof(data)
 


### PR DESCRIPTION
When using one of the tpm2-tss deconstructors (Esys_Free and Fapi_Free)
the memory might be freed when there is no more reference to the root
field even when a sub-field is still used, leading to memory corruption.

This solves this by using a custom deconstructor for sub-fields which
keeps a reference to its parent

Fixes https://github.com/tpm2-software/tpm2-pytss/issues/299