### PR TITLE
ci: quote the minimal version in pip command line

### DIFF
--- a/.ci/install-deps.sh
+++ b/.ci/install-deps.sh
@@ -106,7 +106,7 @@ fi
 # Pip version 21.3 was broken with in-pace (-e) installs. Thus use something
 # after it as it was fixed in 21.3.1
 #
-python3 -m pip install --user --upgrade pip>21.3
+python3 -m pip install --user --upgrade 'pip>21.3'
 
 #
 # Install Python Development Dependencies


### PR DESCRIPTION
In shell script, using `... pip>21.3` means "run the command and write the output in a file named `21.3`. This leads to empty output in GitHub Actions, such as in https://github.com/tpm2-software/tpm2-pytss/runs/4703569920?check_suite_focus=true#step:4:2004

Fix this by quoting the parameter, which makes the shell interpret it as a string instead of an output redirection.