### PR TITLE
ESAPI: add check for bad type_/FAPI_CONTEXTLOAD value in load_blob

### DIFF
--- a/test/test_fapi.py
+++ b/test/test_fapi.py
@@ -265,6 +265,14 @@ class Common:
         esys.read_public(esys_handle)
         esys.flush_context(esys_handle)
 
+    def test_get_esys_blob_bad(self, esys):
+        with pytest.raises(ValueError) as e:
+            esys.load_blob(None, 1234)
+        assert (
+            str(e.value)
+            == "Expected type_ to be FAPI_ESYSBLOB.CONTEXTLOAD or FAPI_ESYSBLOB.DESERIALIZE, got 1234"
+        )
+
     def test_get_esys_blob_deserialize(self, esys, nv_ordinary):
         blob_data, blob_type = self.fapi.get_esys_blob(path=nv_ordinary)
         assert blob_type == FAPI_ESYSBLOB.DESERIALIZE

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -6755,6 +6755,9 @@ class ESAPI:
             type_ (int, optional): :const:`FAPI_ESYSBLOB.CONTEXTLOAD` or :const:`FAPI_ESYSBLOB.DESERIALIZE`. Defaults to :const:`FAPI_ESYSBLOB.CONTEXTLOAD`
             if FAPI is installed else :const: `FAPI_ESYSBLOB.DESERIALIZE`.
 
+        Raises:
+            ValueError: If type_ is not of an expected value.
+
         Returns:
             ESYS_TR: The ESAPI handle to the loaded object.
         """
@@ -6766,6 +6769,10 @@ class ESAPI:
             _chkrc(lib.Esys_ContextLoad(self._ctx, key_ctx, esys_handle))
         elif type_ == FAPI_ESYSBLOB.DESERIALIZE:
             _chkrc(lib.Esys_TR_Deserialize(self._ctx, data, len(data), esys_handle))
+        else:
+            raise ValueError(
+                f"Expected type_ to be FAPI_ESYSBLOB.CONTEXTLOAD or FAPI_ESYSBLOB.DESERIALIZE, got {type_}"
+            )
 
         return ESYS_TR(esys_handle[0])
 


### PR DESCRIPTION
Fixes https://github.com/tpm2-software/tpm2-pytss/issues/305