### PR TITLE
ESAPI: fix double-close issue

### DIFF
--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -4716,6 +4716,21 @@ class TestEsys(TSS2_EsapiTest):
         gc.collect()
         self.assertEqual(bytes(algb), TPM2_ALG.SHA256.to_bytes(2, "big"))
 
+    def test_double_close(self):
+        ectx = ESAPI(self.tpm.tcti_name_conf)
+        self.assertTrue(ectx._did_load_tcti)
+        self.assertTrue(ectx._ctx)
+        self.assertTrue(ectx._ctx_pp)
+        self.assertEqual(ectx.tcti.name_conf, self.tpm.tcti_name_conf)
+        ectx.close()
+        self.assertFalse(ectx._ctx)
+        self.assertFalse(ectx._ctx_pp)
+        self.assertEqual(ectx.tcti, None)
+        ectx.close()
+        self.assertFalse(ectx._ctx)
+        self.assertFalse(ectx._ctx_pp)
+        self.assertEqual(ectx.tcti, None)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tpm2_pytss/ESAPI.py
+++ b/tpm2_pytss/ESAPI.py
@@ -148,10 +148,11 @@ class ESAPI:
 
         C Function: Esys_Finalize
         """
-
-        lib.Esys_Finalize(self._ctx_pp)
-        self._ctx = ffi.NULL
-        if self._did_load_tcti:
+        if self._ctx_pp:
+            lib.Esys_Finalize(self._ctx_pp)
+            self._ctx = ffi.NULL
+            self._ctx_pp = ffi.NULL
+        if self._did_load_tcti and self._tcti is not None:
             self._tcti.close()
         self._tcti = None
 


### PR DESCRIPTION
When `ESAPI.close` is called twice, it could raise an exception:

    >>> from tpm2_pytss import *
    >>> ectx = ESAPI("tabrmd:bus_type=system")
    >>> ectx.close()
    >>> ectx.close()
    WARNING:esys:src/tss2-esys/esys_context.c:114:Esys_Finalize() Finalizing NULL context.
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/workspace/tpm2-pytss/tpm2_pytss/ESAPI.py", line 155, in close
        self._tcti.close()

Fix this by ensuring that `self._tcti` is not `None` before calling `close`. While at it, do not call `Esys_Finalize` twice.