### PR TITLE
ci: define DEBIAN_FRONTEND correctly in apt-get

### DIFF
--- a/.ci/install-deps.sh
+++ b/.ci/install-deps.sh
@@ -8,9 +8,8 @@ export TPM2_TSS_VERSION=${TPM2_TSS_VERSION:-"3.0.3"}
 #
 # Get dependencies for building and install tpm2-tss and abrmd projects
 #
-export DEBIAN_FRONTEND=noninteractive
-sudo apt-get update
-sudo apt-get install -y \
+sudo DEBIAN_FRONTEND=noninteractive apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
     autoconf-archive \
     curl \
     libcmocka0 \


### PR DESCRIPTION
When using `sudo apt-get ...`, the environment variables are not forwarded by default. So in fact `apt-get` runs without
`DEBIAN_FRONTEND=noninteractive`. This triggers interactive prompts when running `.ci/install-deps.sh` in a Docker container.

Fix this by defining `DEBIAN_FRONTEND=noninteractive` directly in the `sudo` line.