### PR TITLE
constants: add fixes for tools-like string generation

### DIFF
--- a/test/test_types.py
+++ b/test/test_types.py
@@ -1495,6 +1495,11 @@ class TypesTest(unittest.TestCase):
             str(badattrs)
         self.assertEqual(str(e.exception), "unnmatched values left: 0x80000")
 
+        aw = TPMA_NV.AUTHWRITE | TPMA_NV.AUTHREAD
+        self.assertEqual(str(aw), "authwrite|authread")
+
+        self.assertEqual(str(TPMA_CC()), "")
+
     def test_TPM_FRIENDLY_INTLIST_math(self):
         ab = abs(TPM2_ALG.RSA)
         self.assertIsInstance(ab, TPM2_ALG)

--- a/tpm2_pytss/constants.py
+++ b/tpm2_pytss/constants.py
@@ -267,13 +267,15 @@ class TPMA_FRIENDLY_INTLIST(TPM_FRIENDLY_INT):
         cv = int(self)
         ints = list()
         for k, v in vars(self.__class__).items():
-            if k.startswith("_") or k.startswith("DEFAULT"):
+            if cv == 0:
+                break
+            if not isinstance(v, int) or k.startswith("_") or k.startswith("DEFAULT"):
                 continue
             for fk, fv in self._FIXUP_MAP.items():
                 if k == fv:
                     k = fk
                     break
-            if not v & self:
+            if v == 0 or v & cv != v:
                 continue
             ints.append(k.lower())
             cv = cv ^ v
@@ -1257,7 +1259,7 @@ class TPMA_NV(TPMA_FRIENDLY_INTLIST):
 
 
 @TPM_FRIENDLY_INT._fix_const_type
-class TPMA_CC(TPM_FRIENDLY_INT):
+class TPMA_CC(TPMA_FRIENDLY_INTLIST):
     COMMANDINDEX_MASK = lib.TPMA_CC_COMMANDINDEX_MASK
     COMMANDINDEX_SHIFT = lib.TPMA_CC_COMMANDINDEX_SHIFT
     NV = lib.TPMA_CC_NV


### PR DESCRIPTION
Fixes:
Make TPMA_CC a subclass of TPMA_FRIENDLY_INTLIST
str(TPMA_CC()) returning "commandindex_shift"
str(TPMA_NV.AUTHWRITE | ...) raising ValueError: unnmatched values left: 0x4

