### PR TITLE
ESAPI: fix double-close issue

### DIFF
--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -4716,6 +4716,29 @@ class TestEsys(TSS2_EsapiTest):
         gc.collect()
         self.assertEqual(bytes(algb), TPM2_ALG.SHA256.to_bytes(2, "big"))
 
+    def test_double_close(self):
+
+        # Shutdown the old TCTI connection so we can connect with a name-conf string
+        # without blocking
+        tcti = self.ectx.tcti
+        self.ectx.close()
+        if tcti is not None:
+            tcti.close()
+
+        ectx = ESAPI(self.tpm.tcti_name_conf)
+        self.assertTrue(ectx._did_load_tcti)
+        self.assertTrue(ectx._ctx)
+        self.assertTrue(ectx._ctx_pp)
+        self.assertEqual(ectx.tcti.name_conf, self.tpm.tcti_name_conf)
+        ectx.close()
+        self.assertFalse(ectx._ctx)
+        self.assertFalse(ectx._ctx_pp)
+        self.assertEqual(ectx.tcti, None)
+        ectx.close()
+        self.assertFalse(ectx._ctx)
+        self.assertFalse(ectx._ctx_pp)
+        self.assertEqual(ectx.tcti, None)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When `ESAPI.close` is called twice, it could raise an exception:

    >>> from tpm2_pytss import *
    >>> ectx = ESAPI("tabrmd:bus_type=system")
    >>> ectx.close()
    >>> ectx.close()
    WARNING:esys:src/tss2-esys/esys_context.c:114:Esys_Finalize() Finalizing NULL context.
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/workspace/tpm2-pytss/tpm2_pytss/ESAPI.py", line 155, in close
        self._tcti.close()

Fix this by ensuring that `self._tcti` is not `None` before calling
`close`. While at it, do not call `Esys_Finalize` twice.

Fix a bug in the handling of the logic to close the TCTI in
ESAPI.close(). If a TCTI object is passed to ESAPI(), the close() method
on the TCTI is never invoked and the connection is never terminated,
thus subsequent calls will block as the TPM resource is still held.

Signed-off-by: Nicolas Iooss <nicolas.iooss@ledger.fr>
Signed-off-by: William Roberts <william.c.roberts@intel.com>