### PR TITLE
types: add check in TPMS_CONTEXT.to_tools for session handles

### DIFF
--- a/tpm2_pytss/internal/utils.py
+++ b/tpm2_pytss/internal/utils.py
@@ -9,7 +9,7 @@ from ..TSS2_Exception import TSS2_Exception
 
 try:
     from .versions import _versions
-except ImportError:
+except ImportError as e:
     # this is needed so docs can be generated without building
     if "sphinx" not in sys.modules:
         raise e


### PR DESCRIPTION
Instead of letting the caller keep track of if they passed session_type and
auth_hash to to_tools to get a tpm2-tools session context object raise an
exception if session_type and auth_hash is missing when  savedHandle is is
in the HMAC or policy session ranges.

