### PR TITLE
setup.cfg: remove pkgconfig from install_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,6 @@ setup_requires =
 install_requires =
     cffi>=1.0.0
     asn1crypto
-    pkgconfig
     cryptography
 
 [options.extras_require]


### PR DESCRIPTION
Since commit 10d7b4811706de8dc01dd586fc7a0d4df4c1f17b ("replace runtime pkgconfig usage with a version table") pkgconfig is no longer required at runtime.