### PR TITLE
setup: ignore missing/failing pkgconfig files in version_table

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -176,7 +176,10 @@ class type_generator(build_ext):
     def get_versions(self):
         versions = dict()
         for lib in self.version_libs:
-            versions[lib] = pkgconfig.modversion(lib)
+            try:
+                versions[lib] = pkgconfig.modversion(lib)
+            except pkgconfig.PackageNotFoundError:
+                pass
         return versions
 
     def run(self):


### PR DESCRIPTION
As FAPI support is optional just ignore missing pkgconfig packages.
Missing required ones will make build fail at an earlier stage.
