### PR TITLE
test: try both relative and non-relative paths

### DIFF
--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -4,7 +4,11 @@ import unittest
 
 from tpm2_pytss import *
 from tpm2_pytss.internal import *
-from .TSS2_BaseTest import TSS2_EsapiTest
+
+try:
+    from .TSS2_BaseTest import TSS2_EsapiTest
+except ModuleNotFoundError:
+    from TSS2_BaseTest import TSS2_EsapiTest
 from base64 import b64decode
 from hashlib import sha256, sha384
 

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -5,7 +5,11 @@ import unittest
 import gc
 
 from tpm2_pytss import *
-from .TSS2_BaseTest import TSS2_EsapiTest
+
+try:
+    from .TSS2_BaseTest import TSS2_EsapiTest
+except ModuleNotFoundError:
+    from TSS2_BaseTest import TSS2_EsapiTest
 
 
 class TestEsys(TSS2_EsapiTest):

--- a/test/test_fapi.py
+++ b/test/test_fapi.py
@@ -15,7 +15,10 @@ from tpm2_pytss import *
 
 from tpm2_pytss.internal.utils import is_bug_fixed
 
-from .TSS2_BaseTest import TpmSimulator, TSS2_BaseTest
+try:
+    from .TSS2_BaseTest import TpmSimulator, TSS2_BaseTest
+except ModuleNotFoundError:
+    from TSS2_BaseTest import TpmSimulator, TSS2_BaseTest
 
 pytestmark = pytest.mark.skipif(
     "tpm2_pytss.FAPI" not in sys.modules, reason="FAPI Not Detected"

--- a/test/test_tcti.py
+++ b/test/test_tcti.py
@@ -4,7 +4,11 @@
 import unittest
 
 from tpm2_pytss import *
-from .TSS2_BaseTest import TSS2_EsapiTest
+
+try:
+    from .TSS2_BaseTest import TSS2_EsapiTest
+except ModuleNotFoundError:
+    from TSS2_BaseTest import TSS2_EsapiTest
 
 
 class TestTCTI(TSS2_EsapiTest):

--- a/test/test_tsskey.py
+++ b/test/test_tsskey.py
@@ -2,7 +2,11 @@
 # SPDX-License-Identifier: BSD-3
 from tpm2_pytss import *
 from tpm2_pytss.tsskey import TSSPrivKey, _parent_rsa_template, _parent_ecc_template
-from .TSS2_BaseTest import TSS2_EsapiTest
+
+try:
+    from .TSS2_BaseTest import TSS2_EsapiTest
+except ModuleNotFoundError:
+    from TSS2_BaseTest import TSS2_EsapiTest
 from asn1crypto.core import ObjectIdentifier
 from asn1crypto import pem
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -6,7 +6,11 @@ from tpm2_pytss import *
 from tpm2_pytss.internal.crypto import _generate_seed, private_to_key, public_to_key
 from tpm2_pytss.utils import *
 from tpm2_pytss.internal.templates import _ek
-from .TSS2_BaseTest import TSS2_EsapiTest
+
+try:
+    from .TSS2_BaseTest import TSS2_EsapiTest
+except ModuleNotFoundError:
+    from TSS2_BaseTest import TSS2_EsapiTest
 
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding


### PR DESCRIPTION
For pip install -e . which builds and installs to the local directory,
testing currently works fine, however when the build is elsewhere, the
relative imports fail and should consult PYTHONPATH. Try to relative
import and on fail try the default PATH.

Signed-off-by: William Roberts <william.c.roberts@intel.com>