### PR TITLE
Python versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
-        tss-version: [master, 2.4.0, 2.4.6, 3.0.0, 3.0.3, 3.1.0]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+        tss-version: ['master', '2.4.0', '2.4.6', '3.0.0', '3.0.3', '3.1.0']
         with-fapi: [true]
         include:
-          - python-version: 3.9
-            tss-version: 3.1.0
+          - python-version: '3.9'
+            tss-version: '3.1.0'
             with-fapi: false
 
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
         tss-version: [master, 2.4.0, 2.4.6, 3.0.0, 3.0.3, 3.1.0]
         with-fapi: [true]
         include:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10']
         tss-version: [master, 2.4.0, 2.4.6, 3.0.0, 3.0.3, 3.1.0]
         with-fapi: [true]
         include:

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 [options]
 packages =

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,9 +12,6 @@ classifiers =
     License :: OSI Approved :: BSD License
     Natural Language :: English
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.4
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ setup_requires =
 install_requires =
     cffi>=1.0.0
     asn1crypto
-    cryptography
+    cryptography>=3.0
 
 [options.extras_require]
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,10 +27,12 @@ setup_requires =
     pkgconfig
     cryptography>=3.0
     asn1crypto
+    packaging
 install_requires =
     cffi>=1.0.0
     asn1crypto
     cryptography>=3.0
+    packaging
 
 [options.extras_require]
 dev =

--- a/test/TSS2_BaseTest.py
+++ b/test/TSS2_BaseTest.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-2
 
-from distutils import spawn
+import shutil
 import logging
 import os
 import random
@@ -154,7 +154,7 @@ class TpmSimulator(object):
     def getSimulator():
 
         for sim in TpmSimulator.SIMULATORS:
-            exe = spawn.find_executable(sim.exe)
+            exe = shutil.which(sim.exe)
             if not exe:
                 print(f'Could not find executable: "{sim.exe}"', file=sys.stderr)
                 continue

--- a/tpm2_pytss/internal/utils.py
+++ b/tpm2_pytss/internal/utils.py
@@ -2,7 +2,7 @@
 import logging
 import sys
 from typing import List
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from .._libtpm2_pytss import ffi, lib
 from ..TSS2_Exception import TSS2_Exception
@@ -244,7 +244,12 @@ def _check_bug_fixed(
 def _lib_version_atleast(tss2_lib, version):
     if tss2_lib not in _versions:
         return False
-    libv = LooseVersion(_versions[tss2_lib])
-    lv = LooseVersion(version)
+    # Needed to remove git commit from version strings
+    lib_parts = _versions[tss2_lib].rsplit("-", 1)
+    fixed_lib_version = lib_parts[0]
+    version_parts = version.rsplit("-", 1)
+    fixed_version = version_parts[0]
+    libv = Version(fixed_lib_version)
+    lv = Version(fixed_version)
 
     return libv >= lv


### PR DESCRIPTION
Drop 3.6 and add 3.10 with some fixes for distutils usage.
Also make sure the required version of cryptography is correct