### PR TITLE
versions: fix git describe handling

### DIFF
--- a/test/test_internal.py
+++ b/test/test_internal.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python3 -u
+# SPDX-License-Identifier: BSD-2
+import unittest
+from packaging.version import Version, InvalidVersion
+
+from tpm2_pytss.internal.utils import _lib_version_normalize
+
+
+class InternalTest(unittest.TestCase):
+    def test_lib_version_normalize(self):
+
+        v = _lib_version_normalize("3.1.0-126-g0fd1c5fbbaf2")
+        self.assertEqual(v, Version("3.1.0.dev126"))
+
+        v = _lib_version_normalize("3.1.0-126-g0fd1c5fbbaf2-dirty")
+        self.assertEqual(v, Version("3.1.0a126.dev126"))
+
+        v = _lib_version_normalize("1.1.0-rc0")
+        self.assertEqual(v, Version("1.1.0rc0"))
+
+        v = _lib_version_normalize("1.1.0")
+        self.assertEqual(v, Version("1.1.0"))
+
+        with self.assertRaises(InvalidVersion):
+            _lib_version_normalize("3.1.0-126-g0fd1c5fbbaf2-dirty-bad")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
git describe ahead of tag has three parts:
  - recent tag
  - commits since recent tag
  - current commit
  - possibly a dirty flag if modified

Ignore these in version handling logic to fix:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/wcrobert/workspace/tpm2-pytss/installation/usr/lib/python3.8/site-packages/tpm2_pytss/__init__.py", line 2, in <module>
    from .ESAPI import ESAPI
  File "/home/wcrobert/workspace/tpm2-pytss/installation/usr/lib/python3.8/site-packages/tpm2_pytss/ESAPI.py", line 2, in <module>
    from .types import *
  File "/home/wcrobert/workspace/tpm2-pytss/installation/usr/lib/python3.8/site-packages/tpm2_pytss/types.py", line 23, in <module>
    from tpm2_pytss.internal.crypto import (
  File "/home/wcrobert/workspace/tpm2-pytss/installation/usr/lib/python3.8/site-packages/tpm2_pytss/internal/crypto.py", line 4, in <module>
    from ..constants import TPM2_ALG, TPM2_ECC
  File "/home/wcrobert/workspace/tpm2-pytss/installation/usr/lib/python3.8/site-packages/tpm2_pytss/constants.py", line 778, in <module>
    class TSS2_RC(TPM_BASE_RC):
  File "/home/wcrobert/workspace/tpm2-pytss/installation/usr/lib/python3.8/site-packages/tpm2_pytss/constants.py", line 908, in TSS2_RC
    if _lib_version_atleast("tss2-fapi", "3.0.0"):
  File "/home/wcrobert/workspace/tpm2-pytss/installation/usr/lib/python3.8/site-packages/tpm2_pytss/internal/utils.py", line 252, in _lib_version_atleast
    version_parts = version.rsplit("-", 1)
  File "/home/wcrobert/.local/lib/python3.8/site-packages/packaging/version.py", line 298, in __init__
    raise InvalidVersion("Invalid version: '{0}'".format(version))
packaging.version.InvalidVersion: Invalid version: '3.1.0-126-g0fd1c5fbbaf2'

Signed-off-by: William Roberts <william.c.roberts@intel.com>