### PR TITLE
Build script fixes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,11 +16,10 @@ Under the hood, bindings are provided via `CFFI <https://cffi.readthedocs.io/en/
 
 Supported versions of Python are:
 
-- 3.5
-- 3.6
 - 3.7
 - 3.8
 - 3.9
+- 3.10
 
 .. toctree::
     :hidden:

--- a/scripts/libtss2_build.py
+++ b/scripts/libtss2_build.py
@@ -57,8 +57,8 @@ tss2_header_dirs = get_include_paths(libraries)
 
 found_dir = None
 for hd in tss2_header_dirs:
-    full_path = os.path.join(hd, "tss2")
-    if os.path.isdir(full_path):
+    full_path = os.path.join(hd, "tss2", "tss2_common.h")
+    if os.path.isfile(full_path):
         found_dir = hd
         break
 if found_dir is None:

--- a/tpm2_pytss/utils.py
+++ b/tpm2_pytss/utils.py
@@ -341,7 +341,7 @@ def create_ek_template(
         ektype (str): The endoresment key type.
         nv_read_cb (Callable[Union[int, TPM2_RH]]): The callback to use for reading NV areas.
 
-    None:
+    Note:
         nv_read_cb MUST raise a NoSuchIndex exception if the NV index isn't defined.
 
     Returns:


### PR DESCRIPTION
Some small fixes for the build scripts and documentation fixes.
With this it shouldn't be any issue building on a system where IBMs TSS is installed using the method @diabonas recommended