### PR TITLE
SM2 and SM4 parsing

### DIFF
--- a/test/test_types.py
+++ b/test/test_types.py
@@ -1054,6 +1054,14 @@ class TypesTest(unittest.TestCase):
             templ.parameters.eccDetail.symmetric.mode.camellia, TPM2_ALG.CFB
         )
 
+    def test_TPMT_PUBLIC_parse_ecc_sm4(self):
+        templ = TPMT_PUBLIC.parse(alg="ecc:sm4128cfb")
+        self.assertEqual(templ.parameters.eccDetail.symmetric.algorithm, TPM2_ALG.SM4)
+        self.assertEqual(templ.parameters.eccDetail.symmetric.keyBits.camellia, 128)
+        self.assertEqual(
+            templ.parameters.eccDetail.symmetric.mode.camellia, TPM2_ALG.CFB
+        )
+
     def test_TPMT_PUBLIC_parse_rsa_oaep(self):
         templ = TPMT_PUBLIC.parse(
             "rsa2048:oaep-sha512",
@@ -1081,6 +1089,17 @@ class TypesTest(unittest.TestCase):
         self.assertEqual(templ.parameters.symDetail.sym.algorithm, TPM2_ALG.CAMELLIA)
         self.assertEqual(templ.parameters.symDetail.sym.keyBits.sym, 256)
         self.assertEqual(templ.parameters.symDetail.sym.mode.sym, TPM2_ALG.CFB)
+
+    def test_TPMT_PUBLIC_parse_sm4(self):
+        templ = TPMT_PUBLIC.parse("sm4128cfb")
+        self.assertEqual(templ.type, TPM2_ALG.SYMCIPHER)
+        self.assertEqual(templ.parameters.symDetail.sym.algorithm, TPM2_ALG.SM4)
+        self.assertEqual(templ.parameters.symDetail.sym.keyBits.sym, 128)
+        self.assertEqual(templ.parameters.symDetail.sym.mode.sym, TPM2_ALG.CFB)
+
+        with self.assertRaises(ValueError) as e:
+            TPMT_PUBLIC.parse("sm4256cfb")
+        self.assertEqual(str(e.exception), 'Expected bits to be 128, got: "256"')
 
     def test_TPML_ALG_parse_none(self):
         with self.assertRaises(ValueError):

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -1044,6 +1044,23 @@ class TypesTest(unittest.TestCase):
 
         self.assertEqual(templ.parameters.asymDetail.symmetric.algorithm, TPM2_ALG.NULL)
 
+    def test_TPMT_PUBLIC_parse_ecc_sm2(self):
+
+        templ = TPMT_PUBLIC.parse(alg="ecc_sm2")
+
+        self.assertEqual(templ.nameAlg, TPM2_ALG.SHA256)
+
+        self.assertEqual(
+            templ.objectAttributes, TPMA_OBJECT.DEFAULT_TPM2_TOOLS_CREATE_ATTRS
+        )
+
+        self.assertEqual(templ.type, TPM2_ALG.ECC)
+        self.assertEqual(templ.parameters.eccDetail.curveID, TPM2_ECC_CURVE.SM2_P256)
+
+        self.assertEqual(templ.parameters.eccDetail.scheme.scheme, TPM2_ALG.NULL)
+
+        self.assertEqual(templ.parameters.asymDetail.symmetric.algorithm, TPM2_ALG.NULL)
+
     def test_TPMT_PUBLIC_parse_ecc_camellia(self):
         templ = TPMT_PUBLIC.parse(alg="ecc:camellia128cfb")
         self.assertEqual(

--- a/tpm2_pytss/constants.py
+++ b/tpm2_pytss/constants.py
@@ -503,6 +503,7 @@ class TPM2_ECC(TPM_FRIENDLY_INT):
         "256": "NIST_P256",
         "384": "NIST_P384",
         "521": "NIST_P521",
+        "SM2": "SM2_P256",
     }
 
 

--- a/tpm2_pytss/types.py
+++ b/tpm2_pytss/types.py
@@ -560,6 +560,8 @@ class TPMT_PUBLIC(TPM_OBJECT):
 
         if objstr is None or objstr == "":
             curve = TPM2_ECC_CURVE.NIST_P256
+        elif objstr.startswith("_"):
+            curve = TPM2_ECC_CURVE.parse(objstr[1:])
         else:
             curve = TPM2_ECC_CURVE.parse(objstr)
 


### PR DESCRIPTION
Support SM2 and SM4 parsing in TPMT_PARSE, should behave as the tools.
Fixes https://github.com/tpm2-software/tpm2-pytss/issues/321 and https://github.com/tpm2-software/tpm2-pytss/issues/320