### PR TITLE
Camellia, SM3 and SM4

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -177,6 +177,23 @@ class TestUtils(TSS2_EsapiTest):
         certinfo = self.ectx.activate_credential(handle, phandle, credblob, secret)
         self.assertEqual(b"credential data", bytes(certinfo))
 
+    def test_make_credential_ecc_camellia(self):
+        insens = TPM2B_SENSITIVE_CREATE()
+        phandle, parent, _, _, _ = self.ectx.create_primary(
+            insens, "ecc:camellia128cfb"
+        )
+        self.assertEqual(
+            parent.publicArea.parameters.eccDetail.symmetric.algorithm,
+            TPM2_ALG.CAMELLIA,
+        )
+        private, public, _, _, _ = self.ectx.create(phandle, insens, "ecc")
+        credblob, secret = make_credential(
+            parent, b"credential data", public.get_name()
+        )
+        handle = self.ectx.load(phandle, private, public)
+        certinfo = self.ectx.activate_credential(handle, phandle, credblob, secret)
+        self.assertEqual(b"credential data", bytes(certinfo))
+
     def test_Wrap_rsa(self):
         insens = TPM2B_SENSITIVE_CREATE()
         phandle, parent, _, _, _ = self.ectx.create_primary(insens)

--- a/tpm2_pytss/internal/crypto.py
+++ b/tpm2_pytss/internal/crypto.py
@@ -45,11 +45,21 @@ _digesttable = (
     (TPM2_ALG.SHA3_512, hashes.SHA3_512),
 )
 
+if hasattr(hashes, "SM3"):
+    _digesttable += ((TPM2_ALG.SM3_256, hashes.SM3),)
+
 _algtable = (
     (TPM2_ALG.AES, AES),
     (TPM2_ALG.CAMELLIA, Camellia),
     (TPM2_ALG.CFB, modes.CFB),
 )
+
+try:
+    from cryptography.hazmat.primitives.ciphers.algorithms import SM4
+
+    _algtable += ((TPM2_ALG.SM4, SM4),)
+except ImportError:
+    pass
 
 
 def _get_curveid(curve):

--- a/tpm2_pytss/internal/crypto.py
+++ b/tpm2_pytss/internal/crypto.py
@@ -19,8 +19,8 @@ from cryptography.hazmat.primitives.serialization import (
 from cryptography.x509 import load_pem_x509_certificate, load_der_x509_certificate
 from cryptography.hazmat.primitives.kdf.kbkdf import CounterLocation, KBKDFHMAC, Mode
 from cryptography.hazmat.primitives.kdf.concatkdf import ConcatKDFHash
-from cryptography.hazmat.primitives.ciphers.algorithms import AES
-from cryptography.hazmat.primitives.ciphers import modes, Cipher
+from cryptography.hazmat.primitives.ciphers.algorithms import AES, Camellia
+from cryptography.hazmat.primitives.ciphers import modes, Cipher, CipherAlgorithm
 from cryptography.hazmat.backends import default_backend
 from cryptography.exceptions import UnsupportedAlgorithm, InvalidSignature
 from typing import Tuple, Type
@@ -47,6 +47,7 @@ _digesttable = (
 
 _algtable = (
     (TPM2_ALG.AES, AES),
+    (TPM2_ALG.CAMELLIA, Camellia),
     (TPM2_ALG.CFB, modes.CFB),
 )
 
@@ -597,7 +598,7 @@ def _check_hmac(
     h.verify(expected)
 
 
-def _encrypt(cipher: Type[AES], key: bytes, data: bytes) -> bytes:
+def _encrypt(cipher: Type[CipherAlgorithm], key: bytes, data: bytes) -> bytes:
     iv = len(key) * b"\x00"
     ci = cipher(key)
     ciph = Cipher(ci, modes.CFB(iv), backend=default_backend())
@@ -606,7 +607,7 @@ def _encrypt(cipher: Type[AES], key: bytes, data: bytes) -> bytes:
     return encdata
 
 
-def _decrypt(cipher: Type[AES], key: bytes, data: bytes) -> bytes:
+def _decrypt(cipher: Type[CipherAlgorithm], key: bytes, data: bytes) -> bytes:
     iv = len(key) * b"\x00"
     ci = cipher(key)
     ciph = Cipher(ci, modes.CFB(iv), backend=default_backend())


### PR DESCRIPTION
SM3 and SM4 support in cryptography was added after they switched to rust so there are some distributions that don't yet support  the rust bindings.
I'm not sure that this is the right way, but the alternatives are either skipping it or create problems for non-x86/ARM systems.