### PR TITLE
ci: verify built wheel

### DIFF
--- a/scripts/get_deps.py
+++ b/scripts/get_deps.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import argparse
+import configparser
+
+
+def main():
+
+    parser = argparse.ArgumentParser(
+        description="Dumps requred dependencies from a setup.cfg file"
+    )
+    parser.add_argument("filename", nargs="?", default="setup.cfg")
+    args = parser.parse_args()
+
+    c = configparser.ConfigParser()
+    c.read(args.filename)
+    packages = c["options"]["setup_requires"].replace("\n", " ").strip()
+    packages += " " + c["options"]["install_requires"].replace("\n", " ").strip()
+    print(packages)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,3 +53,5 @@ dev =
     pytest-xdist
     pytest-cov
     myst-parser
+    build
+    installer


### PR DESCRIPTION
Ensure the CI builds the wheel and installs it and that all paths in the
module resolve and tests run.

related-to: #341

Signed-off-by: William Roberts <william.c.roberts@intel.com>