### PR TITLE
test_encoding: fix expected NV attributes according to tpm2-tools 5.3 release

### DIFF
--- a/.ci/install-deps.sh
+++ b/.ci/install-deps.sh
@@ -5,7 +5,7 @@ set -exo pipefail
 
 export TPM2_TSS_VERSION=${TPM2_TSS_VERSION:-"3.0.3"}
 export TPM2_TSS_FAPI=${TPM2_TSS_FAPI:-"true"}
-export TPM2_TOOLS_VERSION=${TPM2_TOOLS_VERSION:-"5.2"}
+export TPM2_TOOLS_VERSION=${TPM2_TOOLS_VERSION:-"5.3"}
 
 #
 # Get dependencies for building and install tpm2-tss and abrmd projects

--- a/test/test_encoding.py
+++ b/test/test_encoding.py
@@ -1188,7 +1188,7 @@ class ToolsTest(TSS2_BaseTest):
         nvp = from_yaml(yml, TPMS_NV_PUBLIC())
         self.assertEqual(nvp.nvIndex, 0x1800004)
         self.assertEqual(nvp.nameAlg, TPM2_ALG.SHA256)
-        self.assertEqual(nvp.attributes, 0x6000600)
+        self.assertEqual(nvp.attributes, 0x60006)
         self.assertEqual(nvp.dataSize, 8)
 
     def test_tools_decode_tpmt_public(self):


### PR DESCRIPTION
tpm2-tools 5.3 fixed the wrong output of NV index attributes (cf. https://github.com/tpm2-software/tpm2-tools/issues/3053 and https://github.com/tpm2-software/tpm2-tools/commit/8ec91507a2ecb641e449eb1cd85b6fd67a265198), so the expected value in tpm2-pytss needs to be adjusted accordingly.