### PR TITLE
Make the build reproducible

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@
 #
 import os
 import sys
+import time
 import datetime
 import subprocess
 
@@ -57,7 +58,10 @@ import tpm2_pytss
 
 project = "tpm2-pytss"
 author = "tpm2-software"
-copyright = f"2019 - {datetime.datetime.today().year}, {author}"
+build_date = datetime.datetime.utcfromtimestamp(
+    int(os.environ.get("SOURCE_DATE_EPOCH", time.time()))
+)
+copyright = f"2019 - {build_date.year}, {author}"
 
 # The short X.Y version
 version = get_version(root="..", relative_to=__file__)


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort I noticed that tpm2-pytss could not be built reproducibly.

This is due to the documentation embedding the current build date. This PR results in the build system using a date seeded from the [`SOURCE_DATE_EPOCH` environment variable](https://reproducible-builds.org/specs/source-date-epoch/)... if it exists.

I originally filed this in Debian as bug [#1022777](https://bugs.debian.org/1022777).