### PR TITLE
test: skip test when camellia not supported

### DIFF
--- a/test/TSS2_BaseTest.py
+++ b/test/TSS2_BaseTest.py
@@ -192,6 +192,9 @@ class TSS2_EsapiTest(TSS2_BaseTest):
         self.tcti = None
         self.ectx = None
 
+    def skipIfAlgNotSupported(self, alg: TPM2_ALG):
+        self.skipTest(f'Algorithm "{alg}" not supported by simulator')
+
     def setUp(self):
         super().setUp()
         try:
@@ -204,6 +207,15 @@ class TSS2_EsapiTest(TSS2_BaseTest):
             raise e
         self.tcti = self.tpm.get_tcti()
         self.ectx = ESAPI(self.tcti)
+
+        # record the supported algorithms
+        self._supported_algs = []
+        more = True
+        while more:
+            more, data = self.ectx.get_capability(
+                TPM2_CAP.ALGS, 0, lib.TPM2_MAX_CAP_ALGS
+            )
+            self._supported_algs += [x.alg for x in data.data.algorithms]
 
     def tearDown(self):
         self.ectx.close()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -184,6 +184,7 @@ class TestUtils(TSS2_EsapiTest):
         self.assertEqual(b"credential data", bytes(certinfo))
 
     def test_make_credential_ecc_camellia(self):
+        self.skipIfAlgNotSupported(TPM2_ALG.CAMELLIA)
         insens = TPM2B_SENSITIVE_CREATE()
         phandle, parent, _, _, _ = self.ectx.create_primary(
             insens, "ecc:camellia128cfb"
@@ -205,22 +206,10 @@ class TestUtils(TSS2_EsapiTest):
             self.skipTest("SM4 is not supported by the cryptography module")
         elif _get_digest(TPM2_ALG.SM3_256) is None:
             self.skipTest("SM3 is not supported by the cryptography module")
-        has_sm4 = False
-        has_sm3 = False
-        more = True
-        while more:
-            more, data = self.ectx.get_capability(
-                TPM2_CAP.ALGS, 0, lib.TPM2_MAX_CAP_ALGS
-            )
-            algs = [x.alg for x in data.data.algorithms]
-            if TPM2_ALG.SM4 in algs:
-                has_sm4 = True
-            if TPM2_ALG.SM3_256 in algs:
-                has_sm3 = True
-        if not has_sm4:
-            self.skipTest("SM4 not supported by simulator")
-        elif not has_sm3:
-            self.skipTest("SM3 not supported by simulator")
+
+        self.skipIfAlgNotSupported(TPM2_ALG.SM3_256)
+        self.skipIfAlgNotSupported(TPM2_ALG.SM4)
+
         insens = TPM2B_SENSITIVE_CREATE()
         templ = TPM2B_PUBLIC.parse("ecc:sm4128cfb", nameAlg=TPM2_ALG.SM3_256)
         phandle, parent, _, _, _ = self.ectx.create_primary(insens, templ)


### PR DESCRIPTION
When the simulator doesn't support camellia, this exception is thrown and the test fails:

FAILED test/test_utils.py::TestUtils::test_make_credential_ecc_camellia - tpm2_pytss.TSS2_Exception.TSS2_Exception: tpm:parameter(2):unsupporte...

Fix it by skipping the test and also add a helper that when setting up the test framework also caches the supported algoirthms and has a helper for skipping tests when the TPM simulator lacks support.

Signed-off-by: William Roberts <william.c.roberts@intel.com>