### PR TITLE
docs: fix escape in ESAPI.load_blob

### DIFF
--- a/src/tpm2_pytss/ESAPI.py
+++ b/src/tpm2_pytss/ESAPI.py
@@ -6777,7 +6777,7 @@ class ESAPI:
               if FAPI is installed else :const:`constants.FAPI_ESYSBLOB.DESERIALIZE`.
 
         Raises:
-            ValueError: If type\_ is not of an expected value.
+            ValueError: If type\\_ is not of an expected value.
 
         Returns:
             ESYS_TR: The ESAPI handle to the loaded object.


### PR DESCRIPTION
Using 'type_' makes sphinx throw a warning/error.
Using 'type\_' will give a DeprecationWarning from python.
Using 'type\\_' Will make the inline documentation look weird.

Lets go with the last alternative.

Fixes https://github.com/tpm2-software/tpm2-pytss/issues/382
