### PR TITLE
test: ensure that simulator processes are terminated/killed

### DIFF
--- a/test/TSS2_BaseTest.py
+++ b/test/TSS2_BaseTest.py
@@ -56,12 +56,21 @@ class BaseTpmSimulator(object):
                 self._port = random_port
                 logger.debug(f"started {self.exe} on port {random_port}\n")
                 break
+            else:
+                sim.kill()
 
         if not tpm:
             raise SystemError("Could not start simulator")
 
     def close(self):
+        if self.tpm.poll() is not None:
+            return
         self.tpm.terminate()
+        try:
+            self.tpm.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            self.tpm.kill()
+        self.tpm.wait(timeout=10)
 
     def __str__(self):
         return self.exe


### PR DESCRIPTION
Seems that we leak simulator processes if the simulator is not ready within about one second, so kill the subprocess if it's not ready.

Also ensure the simulator is killed in test teardown to avoid building up a set of processes which might slow down the build.

This should solve the issue where the parts of the CI flow which run after the tests runs very slow which is due to swtpm processes running in the background using the CPU and only leaving ~10% of the CPU to the CI processes.

Related to https://github.com/tpm2-software/tpm2-pytss/issues/381