### PR TITLE
Cache deps

### DIFF
--- a/.ci/install-deps.sh
+++ b/.ci/install-deps.sh
@@ -66,12 +66,15 @@ if ! pkg-config tss2-sys; then
     extra_configure_flags="--disable-fapi"
   fi
   ./bootstrap
-  ./configure --sysconfdir=/etc ${extra_configure_flags} CFLAGS=-g
-  make -j4
-  sudo make install
+  ./configure --prefix="${CI_DEPS_PATH}" ${extra_configure_flags} CFLAGS=-g
+  make -j$(nproc)
+  make install
   sudo ldconfig
   popd
 fi
+
+# link ${CI_DEPS_PATH}/etc/tpm2-tss to /etc/ for the FAPI tests
+sudo ln -s "${CI_DEPS_PATH}/etc/tpm2-tss" /etc/
 
 #
 # Get a simulator

--- a/.ci/install-deps.sh
+++ b/.ci/install-deps.sh
@@ -126,9 +126,9 @@ if ! command -v tpm2; then
     --branch "${TPM2_TOOLS_VERSION}" https://github.com/tpm2-software/tpm2-tools.git
   pushd /tmp/tpm2-tools
   ./bootstrap
-  ./configure CFLAGS=-g --disable-fapi
+  ./configure CFLAGS=-g --prefix="${CI_DEPS_PATH}" --disable-fapi
   make -j$(nproc)
-  sudo make install
+  make install
   popd
 fi
 

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -5,6 +5,12 @@ if [ -d "${HOME}/.local/bin" ]; then
   export PATH="${HOME}/.local/bin:${PATH}"
 fi
 
+# Setup environment for using cached libraries/binaries
+export CI_DEPS_PATH="${HOME}/cideps"
+export PATH="${PATH}:${CI_DEPS_PATH}/bin"
+export PKG_CONFIG_PATH="${CI_DEPS_PATH}/lib/pkgconfig"
+export LD_LIBRARY_PATH="${CI_DEPS_PATH}/lib/"
+
 SRC_ROOT=${SRC_ROOT:-"${PWD}"}
 PYTHON=${PYTHON:-"python3"}
 

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -7,9 +7,9 @@ fi
 
 # Setup environment for using cached libraries/binaries
 export CI_DEPS_PATH="${HOME}/cideps"
-export PATH="${PATH}:${CI_DEPS_PATH}/bin"
-export PKG_CONFIG_PATH="${CI_DEPS_PATH}/lib/pkgconfig"
-export LD_LIBRARY_PATH="${CI_DEPS_PATH}/lib/"
+export PATH="${PATH:+${PATH}:}${CI_DEPS_PATH}/bin"
+export PKG_CONFIG_PATH="${PKG_CONFIG_PATH:+${PKG_CONFIG_PATH}:}${CI_DEPS_PATH}/lib/pkgconfig"
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+${LD_LIBRARY_PATH}:}${CI_DEPS_PATH}/lib/"
 
 SRC_ROOT=${SRC_ROOT:-"${PWD}"}
 PYTHON=${PYTHON:-"python3"}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -57,6 +57,17 @@ jobs:
           path: ~/cideps/bin/tpm2*
           key: tools-${{ matrix.tools-version }}-${{ matrix.tss-version }}
 
+      - name: cache tpm2-tss
+        uses: actions/cache@v3
+        if: matrix.tss-version != 'master'
+        with:
+          path: |
+            ~/cideps/lib/libtss2-*
+            ~/cideps/lib/pkgconfig/tss2-*
+            ~/cideps/include/tss2
+            ~/cideps/etc/tpm2-tss
+          key: tss2-${{ matrix.tss-version }}-c1
+
       - name: Install dependencies
         env:
           TPM2_TSS_VERSION: ${{ matrix.tss-version }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,11 +10,14 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         tss-version: ['master', '2.4.0', '3.0.0', '3.0.3', '3.2.0', '4.0.0']
         with-fapi: [true]
-        tools-version: ['5.5']
+        tools-version: ['5.6']
         include:
           - python-version: '3.9'
             tss-version: '3.1.0'
             with-fapi: false
+          - python-version: '3.12'
+            tss-version: 'master'
+            tools-version: 'master'
 
 
     steps:
@@ -46,6 +49,13 @@ jobs:
         with:
           path: ~/cideps/bin/tpm_server
           key: ibmswtpm2
+
+      - name: cache tpm2-tools
+        uses: actions/cache@v3
+        if: matrix.tools-version != 'master'
+        with:
+          path: ~/cideps/bin/tpm2*
+          key: tools-${{ matrix.tools-version }}-${{ matrix.tss-version }}
 
       - name: Install dependencies
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,6 +26,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ hashFiles('**/setup.cfg') }}
+
       - name: Install dependencies
         env:
           TPM2_TSS_VERSION: ${{ matrix.tss-version }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,6 +32,21 @@ jobs:
           path: ~/.cache/pip
           key: pip-${{ hashFiles('**/setup.cfg') }}
 
+      - name: cache swtpm
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/cideps/lib/libtpms.so*
+            ~/cideps/bin/swtpm
+            ~/cideps/lib/swtpm/libswtpm_libtpms.so*
+          key: swtpm
+
+      - name: cache ibmswtpm2
+        uses: actions/cache@v3
+        with:
+          path: ~/cideps/bin/tpm_server
+          key: ibmswtpm2
+
       - name: Install dependencies
         env:
           TPM2_TSS_VERSION: ${{ matrix.tss-version }}


### PR DESCRIPTION
Cache dependencies between runs, excluding jobs that use the tpm2-tss master branch there is a reduction in runtime from 5-7 minutes to 3-4 minutes, this in combination with https://github.com/tpm2-software/tpm2-pytss/pull/388 should decrease time to feedback for pull requests.

The only issue is that the cache is only valid for one week, so a new pull request after a week of inactivity will still take some time.