### PR TITLE
Pure python TCTI Interface

### DIFF
--- a/scripts/libtss2_build.py
+++ b/scripts/libtss2_build.py
@@ -65,6 +65,18 @@ source = """
     #include <tss2/tss2_tctildr.h>
     #include <tss2/tss2_rc.h>
     #include <tss2/tss2_mu.h>
+
+    /*
+     * Add the structure for the Python TCTI which is the TCTI structure and void *
+     * for the pyobject representing the object instance. We add it here and to
+     * prepare headers so CFFI knows about it (prepare_headers) and here so
+     * C code knows about it.
+     */
+    typedef struct PYTCTI_CONTEXT PYTCTI_CONTEXT;
+    struct PYTCTI_CONTEXT {
+        TSS2_TCTI_CONTEXT_COMMON_V2 common;
+        void *thiz;
+    };
 """
 
 if build_fapi:

--- a/scripts/prepare_headers.py
+++ b/scripts/prepare_headers.py
@@ -111,6 +111,49 @@ def prepare_tcti(dirpath):
     };
     """
 
+    # Add the callbacks for a TCTI
+    s += """
+    extern "Python" TSS2_RC _tcti_transmit_wrapper (
+        TSS2_TCTI_CONTEXT *tctiContext,
+        size_t size,
+        uint8_t const *command);
+
+    extern "Python" TSS2_RC _tcti_receive_wrapper (
+        TSS2_TCTI_CONTEXT *tctiContext,
+        size_t *size,
+        uint8_t *response,
+        int32_t timeout);
+
+    extern "Python" void _tcti_finalize_wrapper (
+        TSS2_TCTI_CONTEXT *tctiContext);
+
+    extern "Python" TSS2_RC _tcti_cancel_wrapper (
+        TSS2_TCTI_CONTEXT *tctiContext);
+
+    extern "Python" TSS2_RC _tcti_get_pollfds_wrapper (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    TSS2_TCTI_POLL_HANDLE *handles,
+    size_t *num_handles);
+
+    extern "Python" TSS2_RC _tcti_set_locality_wrapper (
+        TSS2_TCTI_CONTEXT *tctiContext,
+        uint8_t locality);
+
+    extern "Python" TSS2_RC _tcti_make_sticky_wrapper (
+        TSS2_TCTI_CONTEXT *tctiContext,
+        TPM2_HANDLE *handle,
+        uint8_t sticky);
+    """
+
+    # Add this struct here so CFFI knows about it and its size
+    s += """
+    typedef struct PYTCTI_CONTEXT PYTCTI_CONTEXT;
+    struct PYTCTI_CONTEXT {
+        TSS2_TCTI_CONTEXT_COMMON_V2 common;
+        void *thiz;
+    };
+    """
+
     return remove_common_guards(s)
 
 

--- a/src/tpm2_pytss/TCTI.py
+++ b/src/tpm2_pytss/TCTI.py
@@ -1,70 +1,249 @@
 # SPDX-License-Identifier: BSD-2
 
-from ._libtpm2_pytss import ffi
+from ._libtpm2_pytss import ffi, lib
 
 from .internal.utils import _chkrc
+from .constants import TSS2_RC, TPM2_RC
+from .TSS2_Exception import TSS2_Exception
+
+import os
+from typing import Optional, Tuple, Union
+
+
+class PollData(object):
+    """Initialize a PollData object with OS specific details.
+
+    Initialize a PollData object that holds all OS specific state and metadata information
+    for using in the platforms specific asynchronous IO "polling" system. For Linux this
+    is Poll, Windows is WaitForSingleObject or other interfaces. Only posix systems currently
+    support the events attribute. The system is identified by `os.name`.
+
+    Args:
+        fd (int): The File Descriptor(fd) for posix systems or Opque Handle for other systems.
+        events (int): The event mask, only for posix systems.
+
+    Returns:
+        An instance of the PollData class.
+    """
+
+    def __init__(self, fd: int = -1, events: int = -1):
+        self._fd = fd
+        self._events = events
+
+    @property
+    def fd(self) -> int:
+        """Gets the File Descriptor or Handle for the asynch I/O wait event.
+
+        Returns:
+            The fd or handle.
+        """
+        return self._fd
+
+    @property
+    def handle(self) -> int:
+        """Gets the File Descriptor or Handle for the asynch I/O wait event.
+
+        Same as attribute fd.
+
+        Returns:
+            The fd or handle.
+        """
+        return self._fd
+
+    @property
+    def events(self) -> int:
+        """Gets the Event Mask for the asynch I/O wait event. Suitable for poll.
+
+        Returns:
+            The poll event mask.
+
+        Raises:
+            NotImplementedError if os.name does not equal "posix".
+        """
+        if os.name != "posix":
+            raise NotImplementedError(
+                f"Non POSIX os detected, pollin events not supported, got: {os.name}"
+            )
+        return self._events
+
+
+def common_checks(version=1, null_ok=False):
+    def decorator(func):
+        def wrapper(self, *args, **kwargs):
+            def camel_case(s):
+                from re import sub
+
+                s = sub(r"(_|-)+", " ", s).title().replace(" ", "")
+                return "".join([s[0].lower(), s[1:]])
+
+            if self._v1.version < 1:
+                raise TSS2_Exception(TSS2_RC.TCTI_RC_ABI_MISMATCH)
+
+            sub_struct = getattr(self, f"_v{version}")
+            if sub_struct is None:
+                raise TSS2_Exception(TSS2_RC.TCTI_RC_NOT_IMPLEMENTED)
+
+            method = func.__name__
+            method = camel_case(method)
+            got_method = getattr(sub_struct, method)
+            if not null_ok and got_method == ffi.NULL:
+                raise TSS2_Exception(TSS2_RC.TCTI_RC_NOT_IMPLEMENTED)
+
+            try:
+                self._clear_exceptions()
+                return func(self, *args, **kwargs)
+            except Exception as e:
+                e = self._get_current_exception(e)
+                self._clear_exceptions()
+                raise e
+
+        return wrapper
+
+    return decorator
 
 
 class TCTI:
-    def __init__(self, ctx):
+    """Initialize a TCTI object.
+
+    Initialize a TCTI from a NATIVE instantiated TCTI.
+
+    Args:
+        ctx (ffi.CData): A TSS2_TCTI_CONTEXT * variable. This would be returned from a TCTIs
+            initialize or TCTILdr routine.
+
+    Returns:
+        An instance of a TCTI.
+    """
+
+    def __init__(self, ctx: ffi.CData):
         self._v1 = ffi.cast("TSS2_TCTI_CONTEXT_COMMON_V1 *", ctx)
         if self._v1.version == 2:
             self._v2 = ffi.cast("TSS2_TCTI_CONTEXT_COMMON_V2 *", ctx)
         else:
             self._v2 = None
         self._ctx = ctx
+        # record the last exception so we can throw across the C boundry without
+        # everything becoming an unknown TSS2_Exception(TSS2_RC.TCTI_RC_GENERAL_FAILURE)
+        # Normal TCTIs cannot make use of this, by Python TCTIs can. Add it to the base class
+        # for subordinate TCTIs to use. This way the TCTI fn calls return the most helpful
+        # error.
+        self._last_exception = None
 
     @property
     def _tcti_context(self):
         return self._ctx
 
     @property
-    def magic(self):
-        return self._v1.magic
+    def magic(self) -> bytes:
+        """Returns the MAGIC string of the TCTI.
+
+        Returns:
+            The magic byte string.
+        """
+
+        # uint64_t in C land by default or let subclass control it
+        magic_len = getattr(self, "_magic_len", 8)
+        return self._v1.magic.to_bytes(magic_len, "big")
 
     @property
-    def version(self):
+    def version(self) -> int:
+        """Returns the VERSION number of the TCTI.
+
+        This is the TCTI interface version NOT the release
+        version of the TCTI. Ie if it implements version 1
+        or version 2 of the spec.
+
+        Returns:
+            The TCTI version number.
+        """
+
         return self._v1.version
 
-    def _common_checks(self, method, version=1):
+    def _clear_exceptions(self):
+        self._last_exception = None
 
-        if self._v1.version < 1:
-            raise TSS2_Exception(TSS2_RC.TCTI_RC_ABI_MISMATCH)
+    def _get_current_exception(self, e: Exception):
+        x = self._last_exception
+        return x if x is not None else e
 
-        sub_struct = getattr(self, f"_v{version}")
-        got_method = getattr(sub_struct, method)
+    @common_checks()
+    def transmit(self, command: bytes) -> None:
+        """Transmits bytes to the TPM.
 
-        if got_method == ffi.NULL:
-            raise TSS2_Exception(TSS2_RC.TCTI_RC_NOT_IMPLEMENTED)
+        Args:
+            command (bytes): The bytes to transmit to the TPM.
 
-    def transmit(self, command):
-        self._common_checks("transmit")
+        Returns:
+            The TCTI version number.
+
+        Raises:
+            TSS2_Exception - Underlying TCTI errors
+            Exception - Underlying Python TCTIs can return anything.
+        """
 
         cmd = ffi.new("uint8_t []", command)
         clen = len(command)
         _chkrc(self._v1.transmit(self._ctx, clen, cmd))
 
-    def receive(self, size=-1, timeout=-1):
-        self._common_checks("receive")
+    @common_checks()
+    def receive(self, size: int = 4096, timeout: int = -1) -> bytes:
+        """Receives bytes from the TPM.
 
-        if size == -1:
+        Args:
+            size (int): The maximum expected response size. Defaults to 4096.
+                Negative values infer the default.
+            timeout (int): The maximum time to wait for a response in milliseconds.
+                Defaults to -1 which will wait indefinitely.
+
+        Returns:
+            The TPM response as bytes.
+
+        Raises:
+            TSS2_Exception - Underlying TCTI errors
+            Exception - Underlying Python TCTIs can return anything.
+        """
+
+        if size < 0:
             size = 4096
+
         resp = ffi.new("uint8_t []", b"\x00" * size)
         rsize = ffi.new("size_t *", size)
         _chkrc(self._v1.receive(self._ctx, rsize, resp, timeout))
+
         return bytes(ffi.buffer(resp, rsize[0]))
 
+    @common_checks(null_ok=True)
     def finalize(self):
+        """Cleans up a TCTI's state and resources."""
+
         if self._v1.finalize != ffi.NULL:
             self._v1.finalize(self._ctx)
 
-    def cancel(self):
-        self._common_checks("cancel")
+    @common_checks()
+    def cancel(self) -> None:
+        """Cancels a current transmit with the TPM.
+
+        Some TCTIs may support the ability to cancel the current
+        I/O Operation with the TPM.
+
+        Raises:
+            TSS2_Exception - Underlying TCTI errors
+            Exception - Underlying Python TCTIs can return anything.
+        """
 
         _chkrc(self._v1.cancel(self._ctx))
 
-    def get_poll_handles(self):
-        self._common_checks("getPollHandles")
+    @common_checks()
+    def get_poll_handles(self) -> Tuple[PollData]:
+        """Gets the poll handles from the TPM.
+
+        Returns:
+            A tuple of PollData objects.
+
+        Raises:
+            TSS2_Exception - Underlying TCTI errors
+            Exception - Underlying Python TCTIs can return anything.
+        """
 
         nhandles = ffi.new("size_t *", 0)
         _chkrc(self._v1.getPollHandles(self._ctx, ffi.NULL, nhandles))
@@ -74,15 +253,44 @@ class TCTI:
         _chkrc(self._v1.getPollHandles(self._ctx, handles, nhandles))
         rh = []
         for i in range(0, nhandles[0]):
-            rh.append(handles[i])
+            if os.name == "posix":
+                pd = PollData(handles[i].fd, handles[i].events)
+            else:
+                pd = PollData(handles[i])
+            rh.append(pd)
         return tuple(rh)
 
-    def set_locality(self, locality):
-        self._common_checks("setLocality")
+    @common_checks()
+    def set_locality(self, locality: int) -> None:
+        """Sets the locality of the current TCTI connection with the TPM.
+
+        Locality is a value that specifies to the TPM whom is making the
+        request. Ie firmware, OS, userspace, etc. For TCTIs and
+        TPMs that support this, this interface allows one to set the
+        locality.
+
+        Args:
+            locality (int): The locality value as an integer.
+
+        Raises:
+            TSS2_Exception - Underlying TCTI errors
+            Exception - Underlying Python TCTIs can return anything.
+        """
+
         _chkrc(self._v1.setLocality(self._ctx, locality))
 
-    def make_sticky(self, handle, sticky):
-        self._common_checks("makeSticky", version=2)
+    @common_checks(version=2)
+    def make_sticky(self, handle: int, sticky: Union[bool, int]) -> None:
+        """Makes an object specified by handle not be flushed by a resource manager.
+
+        Resource Managers (RM) MAY flush transient objects when the client disconnects.
+        Thus this object would need to be re-established later, eg TPM2_Load command,
+        this allows RMs that support the ability to mark this object as non-flushable.
+
+        Raises:
+            TSS2_Exception - Underlying TCTI errors
+            Exception - Underlying Python TCTIs can return anything.
+        """
 
         hptr = ffi.new("TPM2_HANDLE *", handle)
         _chkrc(self._v2.makeSticky(self._ctx, hptr, sticky))
@@ -93,3 +301,275 @@ class TCTI:
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.finalize()
+
+
+# Global callbacks
+@ffi.def_extern()
+def _tcti_transmit_wrapper(ctx, size, command):
+    pi = PyTCTI._cffi_cast(ctx)
+    if not hasattr(pi, "do_transmit"):
+        return TSS2_RC.TCTI_RC_NOT_IMPLEMENTED
+    try:
+        pi.do_transmit(bytes(ffi.buffer(command, size)))
+    except Exception as e:
+        rc = e.rc if isinstance(e, TSS2_Exception) else TSS2_RC.TCTI_RC_GENERAL_FAILURE
+        pi._last_exception = e
+        return rc
+
+    return TPM2_RC.SUCCESS
+
+
+@ffi.def_extern()
+def _tcti_receive_wrapper(ctx, size, response, timeout):
+
+    # Let the allocator know how much we need.
+    pi = PyTCTI._cffi_cast(ctx)
+    if response == ffi.NULL:
+        size[0] = pi._max_size
+        return TPM2_RC.SUCCESS
+
+    if not hasattr(pi, "do_receive"):
+        return TSS2_RC.TCTI_RC_NOT_IMPLEMENTED
+    try:
+        resp = pi.do_receive(timeout)
+        max_size = size[0]
+        if len(resp) > max_size:
+            raise TSS2_Exception(TSS2_RC.TCTI_RC_INSUFFICIENT_BUFFER)
+
+        size[0] = len(resp)
+        ffi.memmove(response, resp, len(resp))
+    except Exception as e:
+        rc = e.rc if isinstance(e, TSS2_Exception) else TSS2_RC.TCTI_RC_GENERAL_FAILURE
+        pi._last_exception = e
+        return rc
+
+    return TPM2_RC.SUCCESS
+
+
+@ffi.def_extern()
+def _tcti_cancel_wrapper(ctx):
+    pi = PyTCTI._cffi_cast(ctx)
+    if not hasattr(pi, "do_cancel"):
+        return TSS2_RC.TCTI_RC_NOT_IMPLEMENTED
+    try:
+        pi.do_cancel()
+    except Exception as e:
+        rc = e.rc if isinstance(e, TSS2_Exception) else TSS2_RC.TCTI_RC_GENERAL_FAILURE
+        pi._last_exception = e
+        return rc
+
+    return TPM2_RC.SUCCESS
+
+
+@ffi.def_extern()
+def _tcti_get_pollfds_wrapper(ctx, handles, cnt):
+    pi = PyTCTI._cffi_cast(ctx)
+    if not hasattr(pi, "do_get_poll_handles"):
+        return TSS2_RC.TCTI_RC_NOT_IMPLEMENTED
+    try:
+        # Populate a cache so Python implementors don't have to be called
+        # for size and then fd's. FDs should be stable.
+        if pi._poll_handle_cache is None:
+            pi._poll_handle_cache = pi.do_get_poll_handles()
+            # Support callers returning None or list
+            if pi._poll_handle_cache is None:
+                pi._poll_handle_cache = ()
+
+        # caller wants size for allocation
+        if handles == ffi.NULL:
+            cnt[0] = len(pi._poll_handle_cache)
+        elif cnt[0] < len(pi._poll_handle_cache):
+            raise TSS2_RC.TCTI_RC_INSUFFICIENT_BUFFER
+        else:
+            cnt[0] = len(pi._poll_handle_cache)
+            # Enumerate didn't work here
+            for i in range(0, cnt[0]):
+                pd = pi._poll_handle_cache[i]
+                # convert platform agnostic into CData
+                if os.name == "posix":
+                    handles[i].fd = pd.fd
+                    handles[i].events = pd.events
+                else:
+                    handles[i] = pd.handle
+    except Exception as e:
+        rc = e.rc if isinstance(e, TSS2_Exception) else TSS2_RC.TCTI_RC_GENERAL_FAILURE
+        pi._last_exception = e
+        return rc
+
+    return TPM2_RC.SUCCESS
+
+
+@ffi.def_extern()
+def _tcti_set_locality_wrapper(ctx, locality):
+    pi = PyTCTI._cffi_cast(ctx)
+    if not hasattr(pi, "do_set_locality"):
+        return TSS2_RC.TCTI_RC_NOT_IMPLEMENTED
+    try:
+        pi.do_set_locality(locality)
+    except Exception as e:
+        rc = e.rc if isinstance(e, TSS2_Exception) else TSS2_RC.TCTI_RC_GENERAL_FAILURE
+        pi._last_exception = e
+        return rc
+
+    return TPM2_RC.SUCCESS
+
+
+@ffi.def_extern()
+def _tcti_make_sticky_wrapper(ctx, handle, sticky):
+    pi = PyTCTI._cffi_cast(ctx)
+    if not hasattr(pi, "do_make_sticky"):
+        return TSS2_RC.TCTI_RC_NOT_IMPLEMENTED
+    try:
+        pi.do_make_sticky(handle, bool(sticky))
+    except Exception as e:
+        rc = e.rc if isinstance(e, TSS2_Exception) else TSS2_RC.TCTI_RC_GENERAL_FAILURE
+        pi._last_exception = e
+        return rc
+
+    return TPM2_RC.SUCCESS
+
+
+class PyTCTI(TCTI):
+    """Subclass for implementing a TCTI in Python.
+
+    Extend this object and implement the following methods:
+        - def do_transmit(self, command: bytes) -> None
+            This method transmits a command buffer to the TPM. This method IS REQUIRED.
+
+        - def do_receive(self, timeout: int) -> bytes:
+            This method receives a response from the TPM and returns it. This method IS REQUIRED
+
+        - def do_cancel(self) -> None:
+             Cancels an I/O operation with the TPM. This method is OPTIONAL.
+
+        - def do_get_poll_handles(self) -> Optional[Tuple[PollData]]:
+             Retrieves PollData objects from the TCTI used for async I/O. This method is OPTIONAL.
+
+        - def do_set_locality(self, locality: int) -> None:
+             Sets the locality in which to communicate with the TPM. This method is OPTIONAL.
+
+        - def do_make_sticky(self, handle: int, is_sticky: bool) -> None:
+             Makes a handle sticky to persist across client exits with an RM. This method is OPTIONAL.
+
+    Note:
+        All methods may throw exceptions as needed.
+        No Finalize is needed as Python objects have __del__.
+
+    Args:
+        max_size (int): The size of the response buffer for callers to allocate. Defaults to 4096.
+        magic (bytes): The magic value for the TCTI, may aid in debugging. Max length is 8, defaults to b"PYTCTI\x00\x00"
+
+    Returns:
+        An instance of the PyTCTI class. It's unusable as is, users should extend it.
+    """
+
+    def __init__(self, max_size: int = 4096, magic: bytes = b"PYTCTI\x00\x00"):
+        # PYTCTI ASCII FOR MAGIC: echo -n "5059544354490000" | xxd -r -cdata
+
+        if len(magic) > 8:
+            raise ValueError(f"Expected magic to be at most 8 bytes, got: {len(magic)}")
+
+        cdata = self._cdata = ffi.new("PYTCTI_CONTEXT *")
+        self._max_size = max_size
+        self._poll_handle_cache = None
+        self._magic_len = len(magic)
+        self._last_exception = None
+        cdata.common.v1.version = 2
+        cdata.common.v1.magic = int.from_bytes(magic, "big")
+        cdata.common.v1.transmit = lib._tcti_transmit_wrapper
+        cdata.common.v1.receive = lib._tcti_receive_wrapper
+        cdata.common.v1.cancel = lib._tcti_cancel_wrapper
+        cdata.common.v1.getPollHandles = lib._tcti_get_pollfds_wrapper
+        cdata.common.v1.setLocality = lib._tcti_set_locality_wrapper
+        cdata.common.makeSticky = lib._tcti_make_sticky_wrapper
+
+        # Keep a pointer to this object in the TCTI Context to use later
+        # This is how we multiplex N objects through a set of static
+        # callbacks. Assign it to an object instance variable to prevent
+        # it from getting GC
+        cdata.thiz = self._thiz = ffi.new_handle(self)
+
+        opaque = ffi.cast("TSS2_TCTI_CONTEXT *", cdata)
+        super().__init__(opaque)
+
+    @staticmethod
+    def _cffi_cast(ctx):
+        ctx = ffi.cast("PYTCTI_CONTEXT *", ctx)
+        return ffi.from_handle(ctx.thiz)
+
+    def do_transmit(self, command: bytes) -> None:
+        """This method transmits a command buffer to the TPM. This method IS REQUIRED.
+
+        Args:
+            command (bytes): The bytes to send to the TPM.
+
+        Raises:
+            NotImplementedError: If a subclass has not implemented this.
+            Exception: Implementations are free to raise any Exception. Exceptions are retained
+            across the native boundary.
+        """
+
+        raise NotImplementedError("Subclass needs to implement do_transmit")
+
+    def do_receive(self, timeout: int) -> bytes:
+        """This method receives a response from the TPM and returns it. This method IS REQUIRED.
+
+        Args:
+            timeout (int): The timeout in milliseconds to wait for the TPM. Negative values mean
+                wait indefinitely.
+
+        Raises:
+            NotImplementedError: If a subclass has not implemented this.
+            Exception: Implementations are free to raise any Exception. Exceptions are retained
+            across the native boundary.
+        """
+
+        raise NotImplementedError("Subclass needs to implement do_receive")
+
+    def do_cancel(self) -> None:
+        """Cancels an I/O operation with the TPM. This method is OPTIONAL.
+
+        Raises:
+            Exception: Implementations are free to raise any Exception. Exceptions are retained
+            across the native boundary.
+        """
+        pass
+
+    def do_get_poll_handles(self) -> Optional[Tuple[PollData]]:
+        """Retrieves PollData objects from the TCTI used for async I/O. This method is OPTIONAL.
+
+        Returns:
+            The tuple of PollData handles or None.
+
+        Raises:
+            Exception: Implementations are free to raise any Exception. Exceptions are retained
+            across the native boundary.
+        """
+        pass
+
+    def do_set_locality(self, locality: int) -> None:
+        """Sets the locality in which to communicate with the TPM. This method is OPTIONAL.
+
+        Args:
+            locality(int): The locality of communication with the TPM.
+
+        Raises:
+            Exception: Implementations are free to raise any Exception. Exceptions are retained
+            across the native boundary.
+        """
+        pass
+
+    def do_make_sticky(self, handle: int, is_sticky: bool) -> None:
+        """Makes a handle sticky to persist across client exits with a Resource Manager. This method is OPTIONAL.
+
+        Note: A sticky object is one a RM doesn't flush when the client closes their connection.
+
+        Args:
+            handle(int): The TPM handle to make sticky.
+            is_sticky(bool): True to make sticky, False to make it not sticky.
+
+        Raises:
+            Exception: Implementations are free to raise any Exception. Exceptions are retained
+            across the native boundary.
+        """
+        pass

--- a/src/tpm2_pytss/TCTI.py
+++ b/src/tpm2_pytss/TCTI.py
@@ -87,3 +87,9 @@ class TCTI:
         hptr = ffi.new("TPM2_HANDLE *", handle)
         _chkrc(self._v2.makeSticky(self._ctx, hptr, sticky))
         return hptr[0]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.finalize()

--- a/src/tpm2_pytss/__init__.py
+++ b/src/tpm2_pytss/__init__.py
@@ -10,7 +10,7 @@ try:
 except NotImplementedError:
     pass
 from .TCTILdr import *
-from .TCTI import TCTI
+from .TCTI import TCTI, PyTCTI, PollData
 from .types import *
 from .constants import *
 from .TSS2_Exception import TSS2_Exception

--- a/test/test_tcti.py
+++ b/test/test_tcti.py
@@ -7,10 +7,41 @@ from tpm2_pytss import *
 from .TSS2_BaseTest import TSS2_EsapiTest
 
 
+class MyTCTI(PyTCTI):
+    def __init__(self, subtcti, magic=None):
+        self._tcti = subtcti
+        if magic is not None:
+            super().__init__(magic=magic)
+        else:
+            super().__init__()
+
+    def do_transmit(self, command):
+        self._tcti.transmit(command)
+
+    def do_receive(self, timeout):
+        return self._tcti.receive()
+
+    def do_cancel(self):
+        self._tcti.cancel()
+
+    def do_get_poll_handles(self):
+        return self._tcti.get_poll_handles()
+
+    def do_set_locality(self, locality):
+        self._tcti.set_locality(locality)
+
+    def do_make_sticky(self, handle, is_sticky):
+        if self._tcti is not None:
+            self._tcti.make_sticky(handle, is_sticky)
+
+        if self._error is not None:
+            raise self._error
+
+
 class TestTCTI(TSS2_EsapiTest):
     def test_init(self):
         self.assertEqual(self.tcti.version, 2)
-        self.assertGreater(self.tcti.magic, 0)
+        self.assertGreater(int.from_bytes(self.tcti.magic, "big"), 0)
 
         v1ctx = ffi.cast("TSS2_TCTI_CONTEXT_COMMON_V1 *", self.tcti._ctx)
         v1ctx.version = 1
@@ -72,6 +103,103 @@ class TestTCTI(TSS2_EsapiTest):
 
         with self.assertRaises(TypeError):
             TCTILdr(name=1234, conf=None)
+
+    def test_custom_pytcti_esapi(self):
+
+        t = MyTCTI(self.tcti)
+        e = ESAPI(t)
+        e.get_random(4)
+
+        e.startup(TPM2_SU.CLEAR)
+
+    def test_custom_pytcti_C_wrapper_transmit_receive(self):
+
+        t = MyTCTI(self.tcti)
+
+        # Go through the C API directly and call transmit and recv
+        t.transmit(b"\x80\x01\x00\x00\x00\x0C\x00\x00\x01\x44\x00\x00")
+        resp = t.receive(-1)
+        self.assertEqual(resp, b"\x80\x01\x00\x00\x00\n\x00\x00\x01\x00")
+
+    def test_custom_pytcti_cancel(self):
+        if getattr(self.tcti, "name", "") == "swtpm":
+            self.skipTest("cancel not supported by swtpm")
+
+        t = MyTCTI(self.tcti)
+
+        t.transmit(b"\x80\x01\x00\x00\x00\x0C\x00\x00\x01\x44\x00\x00")
+        t.cancel()
+
+    def test_custom_pytcti_finalize(self):
+        # This is NOP for the PyTCTI but nothing should break
+        # TODO maybe it should implement it?
+        t = MyTCTI(self.tcti)
+        t.finalize()
+
+    def test_custom_pytcti_get_poll_handles(self):
+        tcti_name = getattr(self.tcti, "name", "")
+        t = MyTCTI(self.tcti)
+        try:
+            handles = t.get_poll_handles()
+            for h in handles:
+                self.assertTrue(isinstance(h, PollData))
+        except TSS2_Exception as e:
+            if e.rc != lib.TSS2_TCTI_RC_NOT_IMPLEMENTED:
+                raise e
+            else:
+                self.skipTest(f"get_poll_handles not supported by {tcti_name}")
+
+    def test_custom_pytcti_set_locality(self):
+        tcti_name = getattr(self.tcti, "name", "")
+        t = MyTCTI(self.tcti)
+        t.set_locality(TPMA_LOCALITY.TWO)
+
+    def test_custom_pytcti_make_sticky(self):
+        t = MyTCTI(None)
+        t._error = None
+        t.make_sticky(0, 0)
+        t.make_sticky(0, 1)
+        t.make_sticky(0, False)
+
+        # Test that throwing an exception shows the originating exception
+        t._error = RuntimeError("Bills Error")
+        with self.assertRaises(RuntimeError, msg="Bills Error"):
+            t.make_sticky(5, True)
+
+        t._v2 = None
+        with self.assertRaises(TSS2_Exception):
+            t.make_sticky(0, 0)
+
+    def test_custom_pytcti_set_locality(self):
+        t = MyTCTI(self.tcti)
+        t.set_locality(TPMA_LOCALITY.TWO)
+
+    def test_custom_pytcti_version(self):
+        t = MyTCTI(None)
+        self.assertEqual(t.version, 2)
+
+    def test_custom_pytcti_magic(self):
+        t = MyTCTI(None)
+        magic = b"PYTCTI\x00\x00"
+        self.assertEqual(t.magic, magic)
+
+        # max magic len
+        magic = b"THISISIT"
+        t = MyTCTI(None, magic)
+        self.assertEqual(t.magic, magic)
+
+        # small magic len
+        magic = b"COOL"
+        t = MyTCTI(None, magic)
+        self.assertEqual(t.magic, magic)
+
+        # min magic
+        magic = b""
+        t = MyTCTI(None, magic)
+        self.assertEqual(t.magic, magic)
+
+        with self.assertRaises(ValueError):
+            t = MyTCTI(None, b"THISISTOOBIG")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Allow for TCTIs to be written in Pure python. This adds much needed Documentation around the TCTI interface and sanity on some types.

I'd like to pull this and bump the release version to 2.0 as we will have some minor API tweaks.

Note: This breaks some of the TCTI API, which AFAIK was unused. The
changes are:
- magic: from int to a bytes, which behaves a little more nicely IMHO.
- get_poll_handles: from a tuple of CData objects into a tuple of
  PollData objects.