### PR TITLE
Auto flush

### DIFF
--- a/src/tpm2_pytss/ESAPI.py
+++ b/src/tpm2_pytss/ESAPI.py
@@ -567,6 +567,31 @@ class ESAPI:
 
         return ESYS_TR(session_handle[0])
 
+    def trsess_get_attributes(self, session: ESYS_TR) -> TPMA_SESSION:
+        """Get session attributes.
+
+        Get a sessions attributes.
+
+        Args:
+            session (ESYS_TR): The session handle.
+
+        Raises:
+            TypeError: If a parameter is not of an expected type.
+            TSS2_Exception: Any of the various TSS2_RC's the lower layers can return.
+
+        Returns:
+            The attributes as a TPMA_SESSION.
+
+        C_Function: Esys_TRSess_GetAttributes
+        """
+        _check_handle_type(session, "session")
+
+        attributes = ffi.new("TPMA_SESSION *")
+
+        _chkrc(lib.Esys_TRSess_GetAttributes(self._ctx, session, attributes))
+
+        return TPMA_SESSION(attributes[0])
+
     def trsess_set_attributes(
         self, session: ESYS_TR, attributes: Union[TPMA_SESSION, int], mask: int = 0xFF
     ) -> None:

--- a/src/tpm2_pytss/types.py
+++ b/src/tpm2_pytss/types.py
@@ -39,6 +39,7 @@ from tpm2_pytss.constants import (
     TPM2_ECC_CURVE,
     TPM2_SE,
     TPM2_HR,
+    TPM2_HT,
 )
 from typing import Union, Tuple, Optional
 import sys
@@ -65,7 +66,10 @@ class ParserAttributeError(Exception):
 class TPM2_HANDLE(int):
     """"A handle to a TPM address"""
 
-    pass
+    @property
+    def type(self) -> TPM2_HT:
+        """TPM2_HT: The handle type"""
+        return TPM2_HT((self >> 24) & 0xFF)
 
 
 class TPM_OBJECT(object):

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -4777,6 +4777,27 @@ class TestEsys(TSS2_EsapiTest):
         with self.assertRaises(TypeError):
             self.ectx.tr_get_tpm_handle(42)
 
+    def test_trsess_get_attributes(self):
+        sym = TPMT_SYM_DEF(algorithm=TPM2_ALG.NULL,)
+
+        session = self.ectx.start_auth_session(
+            tpm_key=ESYS_TR.NONE,
+            bind=ESYS_TR.NONE,
+            session_type=TPM2_SE.POLICY,
+            symmetric=sym,
+            auth_hash=TPM2_ALG.SHA256,
+        )
+
+        attrs = self.ectx.trsess_get_attributes(session)
+        self.assertEqual(attrs, TPMA_SESSION.CONTINUESESSION)
+
+        self.ectx.trsess_set_attributes(
+            session, TPMA_SESSION.AUDIT | TPMA_SESSION.AUDITEXCLUSIVE
+        )
+
+        attrs = self.ectx.trsess_get_attributes(session)
+        self.assertEqual(attrs, TPMA_SESSION.AUDIT | TPMA_SESSION.AUDITEXCLUSIVE)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -1931,6 +1931,13 @@ class TypesTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             bytes(bad)
 
+    def test_TPM2_HANDLE(self):
+        handle = TPM2_HANDLE(TPM2_RH.OWNER)
+        ht = handle.type
+
+        self.assertEqual(ht, TPM2_HT.PERMANENT)
+        self.assertIsInstance(ht, TPM2_HT)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds the following functionality:
* Flush transient/session handles when the ESAPI context is closed if flush_on_close is True (default is True)
* Flush transient/session handles when the destructor is called on a ESYS_TR if flush_on_close is True

Also added ESAPI.trsess_get_attributes and type property to TPM2_HANDLE as they are needed for keeping track of if a session has TPMA_SESSION.CONTINUESESSION set and if a handle is a transient object/session

Fixes https://github.com/tpm2-software/tpm2-pytss/issues/372