### PR TITLE
types: add __bytes__ to TPMT_SIGNATURE

### DIFF
--- a/src/tpm2_pytss/internal/crypto.py
+++ b/src/tpm2_pytss/internal/crypto.py
@@ -402,6 +402,21 @@ def _get_digest_size(alg):
     return dt.digest_size
 
 
+def _get_signature_bytes(sig):
+    if sig.sigAlg in (TPM2_ALG.RSAPSS, TPM2_ALG.RSASSA):
+        rb = bytes(sig.signature.rsapss.sig)
+    elif sig.sigAlg == TPM2_ALG.ECDSA:
+        r = int.from_bytes(sig.signature.ecdsa.signatureR, byteorder="big")
+        s = int.from_bytes(sig.signature.ecdsa.signatureS, byteorder="big")
+        rb = encode_dss_signature(r, s)
+    elif sig.sigAlg == TPM2_ALG.HMAC:
+        rb = bytes(sig.signature.hmac)
+    else:
+        raise TypeError(f"unsupported signature algorithm: {sig.sigAlg}")
+
+    return rb
+
+
 def verify_signature_rsa(signature, key, data):
     dt = _get_digest(signature.signature.any.hashAlg)
     if dt is None:

--- a/src/tpm2_pytss/types.py
+++ b/src/tpm2_pytss/types.py
@@ -29,6 +29,7 @@ from tpm2_pytss.internal.crypto import (
     _public_to_pem,
     _getname,
     _verify_signature,
+    _get_signature_bytes,
     private_to_key,
 )
 import tpm2_pytss.constants as constants  # lgtm [py/import-and-import-from]
@@ -2270,6 +2271,16 @@ class TPMT_SIGNATURE(TPM_OBJECT):
             :py:class:`cryptography.exceptions.InvalidSignature`: when the signature doesn't match the data.
         """
         _verify_signature(self, key, data)
+
+    def __bytes__(self):
+        """Return the underlying bytes for the signature.
+
+        For RSA and HMAC signatures return the signature bytes, for ECDSA return a ASN.1 encoded signature.
+
+        Raises:
+            TypeError: when the signature algorithm is unsupported.
+        """
+        return _get_signature_bytes(self)
 
 
 class TPMU_SIG_SCHEME(TPM_OBJECT):

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -1903,6 +1903,34 @@ class TypesTest(unittest.TestCase):
         self.assertEqual(s.selections.pcr_select.sizeofSelect, 3)
         self.assertEqual(bytes(s.selections.pcr_select.pcrSelect), b"\xFF\xFF\xFF\x00")
 
+    def test_TPMT_SIGNATURE(self):
+        ecdsa = TPMT_SIGNATURE(sigAlg=TPM2_ALG.ECDSA)
+        ecdsa.signature.ecdsa.signatureR = b"\x52" * 32
+        ecdsa.signature.ecdsa.signatureS = b"\x53" * 32
+        ecbytes = bytes(ecdsa)
+
+        self.assertEqual(
+            ecbytes,
+            b"0D\x02 RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR\x02 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
+        )
+
+        rsa = TPMT_SIGNATURE(sigAlg=TPM2_ALG.RSAPSS)
+        rsa.signature.rsapss.sig = b"RSA" * 85
+        rsabytes = bytes(rsa)
+
+        self.assertEqual(rsabytes, b"RSA" * 85)
+
+        hmac = TPMT_SIGNATURE(sigAlg=TPM2_ALG.HMAC)
+        hmac.signature.hmac.hashAlg = TPM2_ALG.SHA256
+        hmac.signature.hmac.digest.sha256 = b"HMAC" * 8
+        hmacbytes = bytes(hmac)
+
+        self.assertEqual(hmacbytes, b"HMAC" * 8)
+
+        bad = TPMT_SIGNATURE(sigAlg=TPM2_ALG.NULL)
+        with self.assertRaises(TypeError):
+            bytes(bad)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Make calling bytes(sig) return the underlying signature bytes. Useful to pass the signature to other APIs/libraries who don't use TPM structures.

Fixes https://github.com/tpm2-software/tpm2-pytss/issues/463