### PR TITLE
scripts: remove "#if ..." when preparing headers

### DIFF
--- a/scripts/prepare_headers.py
+++ b/scripts/prepare_headers.py
@@ -21,6 +21,7 @@ def remove_common_guards(s):
 
     # Remove includes and guards
     s = re.sub("#ifndef.*", "", s)
+    s = re.sub("#if .*", "", s)
     s = re.sub("#define .*_H_*?\n", "", s)
     s = re.sub("#endif.*", "", s)
     s = re.sub("#error.*", "", s)


### PR DESCRIPTION
A recent commit to tpm2-tss adds a "#if ..." to a header, which we where not removing, causing problems for CFFI, so remove any "#if ...".

Fixes https://github.com/tpm2-software/tpm2-pytss/issues/465