### PR TITLE
constants: add routine for making ESYS_TR from parts

### DIFF
--- a/src/tpm2_pytss/constants.py
+++ b/src/tpm2_pytss/constants.py
@@ -436,6 +436,28 @@ class ESYS_TR(TPM_FRIENDLY_INT):
         """
         return ectx.tr_close(self)
 
+    @staticmethod
+    def parts_to_blob(handle: "TPM2_HANDLE", public: "TPM2B_PUBLIC") -> bytes:
+        """Converts a persistent handle and public to a serialized ESYS_TR.
+
+        Args:
+            handle(TPM2_HANDLE): The PERSISTENT handle to convert.
+            public(TPM2B_PUBLIC): The corresponding public for the handle.
+
+        Returns:
+            A SERIALIZED ESYS_TR that can be used with ESYS_TR.deserialize later.
+        """
+
+        if (handle >> TPM2_HR.SHIFT) != TPM2_HT.PERSISTENT:
+            raise ValueError("Expected a persistent handle, got: {handle:#x}")
+
+        b = bytearray()
+        b.extend(handle.to_bytes(4, byteorder="big"))
+        b.extend(public.get_name().marshal())
+        b.extend(int(1).to_bytes(4, byteorder="big"))
+        b.extend(public.marshal())
+        return bytes(b)
+
 
 @TPM_FRIENDLY_INT._fix_const_type
 class TPM2_RH(TPM_FRIENDLY_INT):

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -4864,6 +4864,21 @@ class TestEsys(TSS2_EsapiTest):
         with self.assertRaises(TypeError):
             self.ectx.tr_get_tpm_handle(42)
 
+    def test_tr_parts_to_blob(self):
+
+        esys_handle, public = self.ectx.create_primary(TPM2B_SENSITIVE_CREATE())[0:2]
+        new_handle = self.ectx.evict_control(ESYS_TR.OWNER, esys_handle, 0x81000001)
+        golden = new_handle.serialize(self.ectx)
+
+        tpm_handle = self.ectx.tr_get_tpm_handle(new_handle)
+        self.assertEqual(tpm_handle, 0x81000001)
+
+        blob = ESYS_TR.parts_to_blob(tpm_handle, public)
+        self.assertEqual(golden, blob)
+
+        with self.assertRaises(ValueError):
+            ESYS_TR.parts_to_blob(0x80000000, public)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Relating to the following PRs:
- tpm2-tools: https://github.com/tpm2-software/tpm2-tools/pull/3214
- systemd: https://github.com/williamcroberts/systemd/tree/add-esys-tr-code

Note: systemd is part of a long term strategy with Dan Street and Lennart Pottering over internal representation for disk key parents.

Create a function that takes a persistent handle and TPM2B_PUBLIC and outputs a serialized ESYS_TR. This allows the creation of stable ESYS_TR formats when a TPM is not available.