### PR TITLE
ESAPI: fix check on ESYS_TR in policy_secret

### DIFF
--- a/src/tpm2_pytss/ESAPI.py
+++ b/src/tpm2_pytss/ESAPI.py
@@ -3988,7 +3988,7 @@ class ESAPI:
                 f"expected expiration to be type int, got {type(expiration)}"
             )
 
-        _check_friendly_int(auth_handle, "auth_handle", ESYS_TR)
+        _check_handle_type(auth_handle, "auth_handle")
 
         _check_handle_type(session1, "session1")
         _check_handle_type(session2, "session2")


### PR DESCRIPTION
The check was that the ESYS_TR was a constant in the class, which is not true it could be for a transient or persistent handle, etc.

Fixes:
Traceback (most recent call last):
  File "./edge-main.py", line 79, in <module>
    e.policy_secret(phandle, session, nonce, b"", b"", 0)
  File "/home/wcrobert/workspace/tpm2-pytss/src/tpm2_pytss/ESAPI.py", line 3991, in policy_secret
    _check_friendly_int(auth_handle, "auth_handle", ESYS_TR)
  File "/home/wcrobert/workspace/tpm2-pytss/src/tpm2_pytss/internal/utils.py", line 340, in _check_friendly_int
    raise ValueError(
ValueError: expected auth_handle value of 1078035591 in class <class 'tpm2_pytss.constants.ESYS_TR'>, however it's not found.