### PR TITLE
setup: drop python 3.7

### DIFF
--- a/.github/workflows/publish_pkg.yaml
+++ b/.github/workflows/publish_pkg.yaml
@@ -12,10 +12,10 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v2
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Install Dependencies
       env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         tss-version: ['master', '2.4.0', '3.0.0', '3.0.3', '3.2.0', '4.0.0']
         with-fapi: [true]
         tools-version: ['master']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,6 @@ Under the hood, bindings are provided via `CFFI <https://cffi.readthedocs.io/en/
 
 Supported versions of Python are:
 
-- 3.7
 - 3.8
 - 3.9
 - 3.10

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,6 @@ classifiers =
     License :: OSI Approved :: BSD License
     Natural Language :: English
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10


### PR DESCRIPTION
python 3.7 is unsupported as of 2023-06-27, so don't say we support it or test against it.