### PR TITLE
tctildr: use Tss2_TctiLdr_GetInfo to lookup tcti backend

### DIFF
--- a/src/tpm2_pytss/TCTILdr.py
+++ b/src/tpm2_pytss/TCTILdr.py
@@ -67,3 +67,24 @@ class TCTILdr(TCTI):
 
     def __str__(self):
         return self.name_conf
+
+    @staticmethod
+    def is_available(name=None) -> bool:
+        """Lookup the TCTI and return its availability
+
+        Returns:
+           True if the interface is available
+        """
+        ctx_pp = ffi.new("TSS2_TCTI_INFO **")
+
+        if name is None:
+            name = ffi.NULL
+        elif isinstance(name, str):
+            name = name.encode()
+
+        ret = lib.Tss2_TctiLdr_GetInfo(name, ctx_pp)
+        if ret != lib.TPM2_RC_SUCCESS:
+            return False
+
+        lib.Tss2_TctiLdr_FreeInfo(ctx_pp)
+        return True

--- a/test/TSS2_BaseTest.py
+++ b/test/TSS2_BaseTest.py
@@ -10,8 +10,6 @@ import sys
 import tempfile
 import time
 import unittest
-from ctypes import cdll
-
 
 from tpm2_pytss import *
 
@@ -167,13 +165,7 @@ class TpmSimulator(object):
             if not exe:
                 print(f'Could not find executable: "{sim.exe}"', file=sys.stderr)
                 continue
-            try:
-                cdll.LoadLibrary(sim.libname)
-            except OSError as e:
-                print(
-                    f'Could not load libraries: "{sim.exe}", error: {e}',
-                    file=sys.stderr,
-                )
+            if not TCTILdr.is_available(sim.libname):
                 continue
 
             return sim()

--- a/test/test_tcti.py
+++ b/test/test_tcti.py
@@ -223,6 +223,10 @@ class TestTCTI(TSS2_EsapiTest):
         with self.assertRaises(RuntimeError, msg="Bills Error 2"):
             t.finalize()
 
+    def test_is_available(self):
+        self.assertTrue(TCTILdr.is_available())
+        self.assertFalse(TCTILdr.is_available("this-tcti-doesnt-exist"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
distros may place TCTI backend to different locations than the system libraries.

This commits makes the tests lookup the backend via `Tss2_TctiLdr_GetInfo` instead of of LD_LIBRARY_PATH.