### PR TITLE
scripts: remove references to TPMS_ALGORITHM_DESCRIPTION

### DIFF
--- a/scripts/prepare_headers.py
+++ b/scripts/prepare_headers.py
@@ -82,6 +82,14 @@ def prepare_types(dirpath):
 
     s = remove_INTERNALBUILD(s)
 
+    s = re.sub(
+        "typedef struct TPMS_ALGORITHM_DESCRIPTION TPMS_ALGORITHM_DESCRIPTION ;", "", s
+    )
+
+    s = re.sub(
+        r"struct TPMS_ALGORITHM_DESCRIPTION {\n.*\n.*\n} ;", "", s, flags=re.MULTILINE
+    )
+
     return remove_common_guards(s)
 
 
@@ -277,6 +285,22 @@ def prepare_mu(dirpath):
             1,
             re.DOTALL | re.MULTILINE,
         )
+
+    s = re.sub(
+        r"TSS2_RC\s+Tss2_MU_TPMS_ALGORITHM_DESCRIPTION_Marshal\(.+?\)\s+;",
+        "",
+        s,
+        1,
+        re.DOTALL | re.MULTILINE,
+    )
+
+    s = re.sub(
+        r"TSS2_RC\s+Tss2_MU_TPMS_ALGORITHM_DESCRIPTION_Unmarshal\(.+?\)\s+;",
+        "",
+        s,
+        1,
+        re.DOTALL | re.MULTILINE,
+    )
 
     return s
 


### PR DESCRIPTION
The type TPMS_ALGORITHM_DESCRIPTION and related MU functions has been removed in tpm2-tss 4.0, so don't link against MU functions so building against older tpm2-tss versions and running with newer versions work.