### PR TITLE
readthedocs: switch to os from image

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,10 +3,10 @@
 
 version: 2
 
-# stable is ubuntu-18.04 image
-#   - https://hub.docker.com/r/readthedocs/build/
 build:
-  image: stable
+  os: ubuntu-22.04
+  tools:
+    python: "3"
 
 sphinx:
   builder: html

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -65,7 +65,7 @@ toml==0.10.2
 tomli==2.0.0
 tqdm==4.62.3
 twine==3.7.1
-typed-ast==1.5.1
+typed-ast==1.5.5
 typing-extensions==4.0.1
 urllib3==1.26.7
 webencodings==0.5.1


### PR DESCRIPTION
readthedocks builds reports:
"""
Error

The configuration key "build.image" is deprecated. Use "build.os" instead to continue building your project. Read more at https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os """

So switch to build.os.