### PR TITLE
test: test against python 3.12

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         tss-version: ['master', '2.4.0', '3.0.0', '3.0.3', '3.2.0', '4.0.0']
         with-fapi: [true]
         tools-version: ['5.5']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ Supported versions of Python are:
 - 3.9
 - 3.10
 - 3.11
+- 3.12
 
 .. toctree::
     :hidden:

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 
 [options]
 package_dir=


### PR DESCRIPTION
Python 3.12 is released now, so test against it.