### PR TITLE
fixes / changelog for 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.2.1 - 2024-01-07
+### Fixed
+- Fix tests `pcr_set_auth_value` and `pcr_set_auth_policy` tests when running against libtpms-based simulators.
+- Fix integration with cryptography >= 42.0.1
+
 ## 2.2.0 - 2023-11-30
 ### Fixed
 - Fix pycparse error for __float128.

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -3585,6 +3585,8 @@ class TestEsys(TSS2_EsapiTest):
             self.ectx.pcr_allocate(pcrsels, session3=object())
 
     def test_pcr_set_auth_policy(self):
+        if getattr(self.tcti, "name", "") == "swtpm":
+            self.skipTest("pcr_set_auth_policy not supported by swtpm")
 
         policy = b"0123456789ABCDEF0123456789ABCDEF"
         self.ectx.pcr_set_auth_policy(policy, TPM2_ALG.SHA256, ESYS_TR.PCR20)
@@ -3630,6 +3632,8 @@ class TestEsys(TSS2_EsapiTest):
             )
 
     def test_pcr_set_auth_value(self):
+        if getattr(self.tcti, "name", "") == "swtpm":
+            self.skipTest("pcr_set_auth_value not supported by swtpm")
 
         self.ectx.pcr_set_auth_value(ESYS_TR.PCR20, b"password")
         self.ectx.tr_set_auth(ESYS_TR.PCR20, b"password")

--- a/test/test_fapi.py
+++ b/test/test_fapi.py
@@ -13,7 +13,7 @@ from cryptography.hazmat.primitives.asymmetric.padding import PSS
 
 from tpm2_pytss import *
 
-from tpm2_pytss.internal.utils import is_bug_fixed
+from tpm2_pytss.internal.utils import is_bug_fixed, _lib_version_atleast
 
 from .TSS2_BaseTest import TpmSimulator
 from tpm2_pytss.TSS2_Exception import TSS2_Exception
@@ -614,7 +614,8 @@ class Common:
         self.fapi.sign(key_path, b"\x22" * 32)
 
     @pytest.mark.skipif(
-        not is_bug_fixed(fixed_in="3.2", backports=["2.4.7", "3.0.5", "3.1.1"]),
+        _lib_version_atleast("tss2-fapi", "4.0.1-170")
+        or not is_bug_fixed(fixed_in="3.2", backports=["2.4.7", "3.0.5", "3.1.1"]),
         reason="tpm2-tss bug, see #2084",
     )
     def test_write_authorize_nv(self, esys):
@@ -661,7 +662,8 @@ class Common:
             self.fapi.quote(path=key_path, pcrs=[7, 9])
 
     @pytest.mark.skipif(
-        not is_bug_fixed(fixed_in="3.2", backports=["2.4.7", "3.0.5", "3.1.1"]),
+        _lib_version_atleast("tss2-fapi", "4.0.1-170")
+        or not is_bug_fixed(fixed_in="3.2", backports=["2.4.7", "3.0.5", "3.1.1"]),
         reason="tpm2-tss bug, see #2084",
     )
     def test_authorize_policy(self, sign_key):
@@ -726,7 +728,9 @@ class Common:
             self.fapi.quote(path=key_path, pcrs=[7, 9])
 
     @pytest.mark.skipif(
-        not is_bug_fixed(fixed_in="3.2"), reason="tpm2-tss bug, see #2080"
+        _lib_version_atleast("tss2-fapi", "4.0.1-170")
+        or not is_bug_fixed(fixed_in="3.2"),
+        reason="tpm2-tss bug, see #2080",
     )
     def test_policy_signed(self, cryptography_key):
         # create external signing key used by the signing authority external to the TPM
@@ -788,6 +792,10 @@ class Common:
         with pytest.raises(TSS2_Exception):
             self.fapi.sign(path=key_path, digest=b"\x11" * 32)
 
+    @pytest.mark.skipif(
+        _lib_version_atleast("tss2-fapi", "4.0.1-170"),
+        reason="issue on master branch.",
+    )
     def test_policy_branched(self):
         pcr_index = 15
         pcr_data = b"ABCDEF"
@@ -905,7 +913,8 @@ class Common:
         self.fapi.delete(path=nv_path)
 
     @pytest.mark.skipif(
-        not is_bug_fixed(fixed_in="3.2", backports=["2.4.7", "3.0.5", "3.1.1"]),
+        _lib_version_atleast("tss2-fapi", "4.0.1-170")
+        or not is_bug_fixed(fixed_in="3.2", backports=["2.4.7", "3.0.5", "3.1.1"]),
         reason="tpm2-tss bug, see #2089",
     )
     def test_policy_action(self):


### PR DESCRIPTION
Since [commit][1] in libtpms setting auth values/policies for PCRs are no longer supported.

[1]: https://github.com/stefanberger/libtpms/commit/af4fc0e66df6d012c61aee7c418148fb261d77a9