### PR TITLE
add fixes for some CodeQL warnings

### DIFF
--- a/src/tpm2_pytss/internal/crypto.py
+++ b/src/tpm2_pytss/internal/crypto.py
@@ -26,7 +26,6 @@ from cryptography.exceptions import UnsupportedAlgorithm, InvalidSignature
 from typing import Tuple, Type, Any
 import secrets
 import inspect
-import sys
 
 _curvetable = (
     (TPM2_ECC.NIST_P192, ec.SECP192R1),

--- a/src/tpm2_pytss/internal/utils.py
+++ b/src/tpm2_pytss/internal/utils.py
@@ -145,7 +145,7 @@ class TSS2Version:
         x = other if isinstance(other, int) else other._value
         return self._value < x
 
-    def __lte__(self, other):
+    def __le__(self, other):
         x = other if isinstance(other, int) else other._value
         return self._value <= x
 

--- a/test/TSS2_BaseTest.py
+++ b/test/TSS2_BaseTest.py
@@ -78,7 +78,6 @@ class SwtpmSimulator(BaseTpmSimulator):
     libname = "libtss2-tcti-swtpm.so"
 
     def __init__(self):
-        self._port = None
         super().__init__()
         self.working_dir = tempfile.TemporaryDirectory()
 
@@ -120,7 +119,6 @@ class IBMSimulator(BaseTpmSimulator):
     libname = "libtss2-tcti-mssim.so"
 
     def __init__(self):
-        self._port = None
         super().__init__()
         self.working_dir = tempfile.TemporaryDirectory()
 


### PR DESCRIPTION
* Drop unused import
* Use __le__ instead of __lte__ for TSS2Version
* Drop _port from BaseTPMSimulator subclasses