### PR TITLE
setup/ci: add python 3.13 and drop python 3.8

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         tss-version: ['master', '2.4.0', '3.0.0', '3.0.3', '3.2.0', '4.0.0']
         with-fapi: [true]
         include:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,11 +16,11 @@ Under the hood, bindings are provided via `CFFI <https://cffi.readthedocs.io/en/
 
 Supported versions of Python are:
 
-- 3.8
 - 3.9
 - 3.10
 - 3.11
 - 3.12
+- 3.13
 
 .. toctree::
     :hidden:

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,11 +12,11 @@ classifiers =
     License :: OSI Approved :: BSD License
     Natural Language :: English
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
 
 [options]
 package_dir=


### PR DESCRIPTION
3.8 is no longer supported upstream and 3.13 has been released.