### PR TITLE
ci/dev: upgrade to black version 24

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -86,7 +86,7 @@ jobs:
     - name: Install Dependencies
       run: |
         python3 -m pip install --user --upgrade pip
-        python3 -m pip install --user --upgrade black==19.10b0
+        python3 -m pip install --user --upgrade black~=24.0
 
     - name: Check
       env:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -3,7 +3,7 @@ Contributing
 
 To contribute, please publish a PR and:
 
-- Keep within the existing style of black. The known working version is: ``19.10b0``.
+- Keep within the existing style of black. The known working version is: ``~24.0``.
 - `Write a good commit message <https://www.freecodecamp.org/news/writing-good-commit-messages-a-practical-guide/>`_.
 
   - If possible prefix your commit with the affected subsystem and colon. For instance, if modifying docs do ``docs: my commit message``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 
 [tool.black]
+required-version = 24
 exclude = '''
 (
   /(

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ dev =
     sphinx-rtd-theme
     twine
     setuptools_scm[toml]>=3.4.3
-    black==19.10b0
+    black~=24.0
     pytest
     pytest-xdist
     pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -261,14 +261,17 @@ class type_generator(build_ext):
         for k, v in type_map.items():
             (t, f) = k
             mstr = mstr + f'    ("{t}", "{f}"): "{v}",\n'
+        mstr = mstr.rstrip()
         estr = ""
         for k, v in element_type_map.items():
             estr = estr + f'    "{k}": "{v}",\n'
+        estr = estr.rstrip()
 
         versions = self.get_versions()
         vstr = ""
         for k, v in versions.items():
             vstr = vstr + f'    "{k}": "{v}",\n'
+        vstr = vstr.rstrip()
 
         p = os.path.join(self.build_lib, "tpm2_pytss/internal/type_mapping.py")
         sp = os.path.join(
@@ -285,10 +288,10 @@ class type_generator(build_ext):
         print(f"generated _versions with {len(versions)} versions")
 
         stempl = dedent(self.map_template)
-        mout = stempl.format(mstr=mstr, estr=estr)
+        mout = stempl.format(mstr=mstr, estr=estr).lstrip()
 
         vtempl = dedent(self.version_template)
-        vout = vtempl.format(vstr=vstr)
+        vout = vtempl.format(vstr=vstr).lstrip()
 
         if not self.dry_run:
             self.mkpath(os.path.dirname(p))

--- a/src/tpm2_pytss/ESAPI.py
+++ b/src/tpm2_pytss/ESAPI.py
@@ -222,7 +222,7 @@ class ESAPI:
         obj = ffi.new("ESYS_TR *")
         _chkrc(
             lib.Esys_TR_FromTPMPublic(
-                self._ctx, handle, session1, session2, session3, obj,
+                self._ctx, handle, session1, session2, session3, obj
             )
         )
         return ESYS_TR(obj[0])
@@ -5390,7 +5390,7 @@ class ESAPI:
 
         _chkrc(
             lib.Esys_HierarchyChangeAuth(
-                self._ctx, auth_handle, session1, session2, session3, new_auth_cdata,
+                self._ctx, auth_handle, session1, session2, session3, new_auth_cdata
             )
         )
 

--- a/src/tpm2_pytss/FAPI.py
+++ b/src/tpm2_pytss/FAPI.py
@@ -320,9 +320,9 @@ class FAPI:
         )
         _chkrc(
             ret,
-            acceptable=[lib.TSS2_FAPI_RC_ALREADY_PROVISIONED]
-            if is_provisioned_ok
-            else None,
+            acceptable=(
+                [lib.TSS2_FAPI_RC_ALREADY_PROVISIONED] if is_provisioned_ok else None
+            ),
         )
         return ret == lib.TPM2_RC_SUCCESS
 

--- a/src/tpm2_pytss/TSS2_Exception.py
+++ b/src/tpm2_pytss/TSS2_Exception.py
@@ -62,5 +62,5 @@ class TSS2_Exception(RuntimeError):
 
     @property
     def fmt1(self):
-        """bool: True if the error is related to a handle, parameter or session """
+        """bool: True if the error is related to a handle, parameter or session."""
         return bool(self._rc & lib.TPM2_RC_FMT1)

--- a/src/tpm2_pytss/constants.py
+++ b/src/tpm2_pytss/constants.py
@@ -35,7 +35,7 @@ class TPM_FRIENDLY_INT(int):
 
     @classmethod
     def iterator(cls) -> filter:
-        """ Returns the constants in the class.
+        """Returns the constants in the class.
 
         Returns:
             (int): The int values of the constants in the class.
@@ -47,7 +47,7 @@ class TPM_FRIENDLY_INT(int):
 
     @classmethod
     def contains(cls, value: int) -> bool:
-        """ Indicates if a class contains a numeric constant.
+        """Indicates if a class contains a numeric constant.
 
         Args:
             value (int): The raw numerical number to test for.
@@ -62,7 +62,7 @@ class TPM_FRIENDLY_INT(int):
 
     @classmethod
     def to_string(cls, value: int) -> str:
-        """ Converts an integer value into it's friendly string name for that class.
+        """Converts an integer value into it's friendly string name for that class.
 
         Args:
             value (int): The raw numerical number to try and convert to a name.
@@ -289,7 +289,7 @@ class TPMA_FRIENDLY_INTLIST(TPM_FRIENDLY_INT):
 
     @classmethod
     def parse(cls, value: str) -> int:
-        """ Converts a string of | separated constant values into it's integer value.
+        """Converts a string of | separated constant values into it's integer value.
 
         Given a pipe "|" separated list of string constant values that represent the
         bitwise values returns the value itself. The value "" (empty string) returns

--- a/src/tpm2_pytss/internal/crypto.py
+++ b/src/tpm2_pytss/internal/crypto.py
@@ -55,28 +55,28 @@ _algtable = (
 
 
 def _get_curveid(curve):
-    for (algid, c) in _curvetable:
+    for algid, c in _curvetable:
         if isinstance(curve, c):
             return algid
     return None
 
 
 def _get_curve(curveid):
-    for (algid, c) in _curvetable:
+    for algid, c in _curvetable:
         if algid == curveid:
             return c
     return None
 
 
 def _get_digest(digestid):
-    for (algid, d) in _digesttable:
+    for algid, d in _digesttable:
         if algid == digestid:
             return d
     return None
 
 
 def _get_pyca_digest(digest_type):
-    for (algid, d) in _digesttable:
+    for algid, d in _digesttable:
         if inspect.isclass(digest_type) and issubclass(digest_type, d):
             return algid
         elif isinstance(digest_type, d):
@@ -85,7 +85,7 @@ def _get_pyca_digest(digest_type):
 
 
 def _get_alg(alg):
-    for (algid, a) in _algtable:
+    for algid, a in _algtable:
         if algid == alg:
             return a
     return None

--- a/src/tpm2_pytss/internal/utils.py
+++ b/src/tpm2_pytss/internal/utils.py
@@ -22,7 +22,7 @@ __MOCK__ = "sphinx" in sys.modules
 
 
 class TSS2Version:
-    """ Class for comparing git describe output
+    """Class for comparing git describe output
 
     Motivation:
     python's packaging version class follows pep-440, however

--- a/src/tpm2_pytss/tsskey.py
+++ b/src/tpm2_pytss/tsskey.py
@@ -98,6 +98,7 @@ _ecc_template = TPMT_PUBLIC(
 
 _loadablekey_oid = ObjectIdentifier("2.23.133.10.1.3")
 
+
 # _BooleanOne is used to encode True in the same way as tpm2-tss-engine
 class _BooleanOne(Boolean):
     def set(self, value):

--- a/src/tpm2_pytss/types.py
+++ b/src/tpm2_pytss/types.py
@@ -57,19 +57,19 @@ from cryptography.hazmat.primitives import serialization
 
 
 class ParserAttributeError(Exception):
-    """ Exception ocurred when when parsing."""
+    """Exception ocurred when when parsing."""
 
     pass
 
 
 class TPM2_HANDLE(int):
-    """"A handle to a TPM address"""
+    """A handle to a TPM address"""
 
     pass
 
 
 class TPM_OBJECT(object):
-    """ Abstract Base class for all TPM Objects. Not suitable for direct instantiation."""
+    """Abstract Base class for all TPM Objects. Not suitable for direct instantiation."""
 
     def __init__(self, _cdata=None, **kwargs):
 
@@ -244,7 +244,7 @@ class TPM_OBJECT(object):
 
 
 class TPM2B_SIMPLE_OBJECT(TPM_OBJECT):
-    """ Abstract Base class for all TPM2B Simple Objects. A Simple object contains only
+    """Abstract Base class for all TPM2B Simple Objects. A Simple object contains only
     a size and byte buffer fields. This is not suitable for direct instantiation."""
 
     def __init__(self, _cdata=None, **kwargs):
@@ -337,7 +337,7 @@ class TPM2B_SIMPLE_OBJECT(TPM_OBJECT):
 
 
 class TPML_Iterator(object):
-    """ Iterator class for iterating over TPML data types.
+    """Iterator class for iterating over TPML data types.
 
     This class is used in enumerated for loops, such as:
     .. code-block:: python
@@ -364,7 +364,7 @@ class TPML_Iterator(object):
 
 
 class TPML_OBJECT(TPM_OBJECT):
-    """ Abstract Base class for all TPML Objects. A TPML object is an object that
+    """Abstract Base class for all TPML Objects. A TPML object is an object that
     contains a list of objects. This is not suitable for direct instantiation."""
 
     def __init__(self, _cdata=None, **kwargs):
@@ -2221,7 +2221,7 @@ class TPMT_SENSITIVE(TPM_OBJECT):
         )
 
         data = k.private_bytes(
-            encoding=encoding, format=format, encryption_algorithm=enc_alg,
+            encoding=encoding, format=format, encryption_algorithm=enc_alg
         )
 
         return data

--- a/test/test_cryptography.py
+++ b/test/test_cryptography.py
@@ -436,10 +436,10 @@ class TestCryptography(TSS2_EsapiTest):
 
         builder = x509.CertificateBuilder()
         builder = builder.subject_name(
-            x509.Name([x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "falafel"),])
+            x509.Name([x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "falafel")])
         )
         builder = builder.issuer_name(
-            x509.Name([x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "falafel"),])
+            x509.Name([x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "falafel")])
         )
         builder = builder.serial_number(x509.random_serial_number())
         one_day = datetime.timedelta(1, 0, 0)
@@ -459,7 +459,7 @@ class TestCryptography(TSS2_EsapiTest):
 
         builder = x509.CertificateSigningRequestBuilder()
         builder = builder.subject_name(
-            x509.Name([x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "falafel"),])
+            x509.Name([x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "falafel")])
         )
         halg = privkey.get_digest_algorithm()
         csr = builder.sign(privkey, algorithm=halg())
@@ -474,10 +474,10 @@ class TestCryptography(TSS2_EsapiTest):
 
         builder = x509.CertificateBuilder()
         builder = builder.subject_name(
-            x509.Name([x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "falafel"),])
+            x509.Name([x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "falafel")])
         )
         builder = builder.issuer_name(
-            x509.Name([x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "falafel"),])
+            x509.Name([x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "falafel")])
         )
         builder = builder.serial_number(x509.random_serial_number())
         one_day = datetime.timedelta(1, 0, 0)
@@ -497,7 +497,7 @@ class TestCryptography(TSS2_EsapiTest):
 
         builder = x509.CertificateSigningRequestBuilder()
         builder = builder.subject_name(
-            x509.Name([x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "falafel"),])
+            x509.Name([x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "falafel")])
         )
         halg = privkey.get_digest_algorithm()
         csr = builder.sign(privkey, algorithm=halg())

--- a/test/test_encoding.py
+++ b/test/test_encoding.py
@@ -68,23 +68,23 @@ class SerializationTest(unittest.TestCase):
         handles = TPMS_CAPABILITY_DATA(capability=TPM2_CAP.HANDLES)
         handles.data.handles = TPML_HANDLE((1,))
         ev = enc.encode(handles)
-        self.assertEqual(ev, {"capability": 1, "data": [1,]})
+        self.assertEqual(ev, {"capability": 1, "data": [1]})
 
         commands = TPMS_CAPABILITY_DATA(capability=TPM2_CAP.COMMANDS)
         cmd = TPM2_CC.NV_Write & TPMA_CC.NV & (2 << TPMA_CC.CHANDLES_SHIFT)
         commands.data.command = TPML_CCA((cmd,))
         ev = enc.encode(commands)
-        self.assertEqual(ev, {"capability": 2, "data": [cmd,]})
+        self.assertEqual(ev, {"capability": 2, "data": [cmd]})
 
         ppcommands = TPMS_CAPABILITY_DATA(capability=TPM2_CAP.PP_COMMANDS)
         ppcommands.data.ppCommands = TPML_CC((3,))
         ev = enc.encode(ppcommands)
-        self.assertEqual(ev, {"capability": 3, "data": [3,]})
+        self.assertEqual(ev, {"capability": 3, "data": [3]})
 
         auditcommands = TPMS_CAPABILITY_DATA(capability=TPM2_CAP.AUDIT_COMMANDS)
         auditcommands.data.auditCommands = TPML_CC((4,))
         ev = enc.encode(auditcommands)
-        self.assertEqual(ev, {"capability": 4, "data": [4,]})
+        self.assertEqual(ev, {"capability": 4, "data": [4]})
 
         pcrs = TPMS_CAPABILITY_DATA(capability=TPM2_CAP.PCRS)
         pcrsel = TPMS_PCR_SELECTION(
@@ -121,7 +121,7 @@ class SerializationTest(unittest.TestCase):
         curves = TPMS_CAPABILITY_DATA(capability=TPM2_CAP.ECC_CURVES)
         curves.data.eccCurves = TPML_ECC_CURVE((TPM2_ECC.SM2_P256,))
         ev = enc.encode(curves)
-        self.assertEqual(ev, {"capability": 8, "data": [0x20,]})
+        self.assertEqual(ev, {"capability": 8, "data": [0x20]})
 
     def test_base_TPMS_ATTEST(self):
         enc = base_encdec()
@@ -190,7 +190,7 @@ class SerializationTest(unittest.TestCase):
             time=TPMS_TIME_INFO(
                 time=1234,
                 clockInfo=TPMS_CLOCK_INFO(
-                    clock=1024, resetCount=2, restartCount=3, safe=False,
+                    clock=1024, resetCount=2, restartCount=3, safe=False
                 ),
             ),
             firmwareVersion=1337,

--- a/test/test_esapi.py
+++ b/test/test_esapi.py
@@ -53,7 +53,7 @@ class TestEsys(TSS2_EsapiTest):
         inPublic.publicArea.parameters.eccDetail.curveID = TPM2_ECC.NIST_P256
 
         handle, public, creation_data, digest, ticket = self.ectx.create_primary(
-            inSensitive, inPublic, ESYS_TR.OWNER, outsideInfo, creationPCR,
+            inSensitive, inPublic, ESYS_TR.OWNER, outsideInfo, creationPCR
         )
         self.assertNotEqual(handle, 0)
         self.assertEqual(type(public), TPM2B_PUBLIC)
@@ -62,7 +62,7 @@ class TestEsys(TSS2_EsapiTest):
         self.assertEqual(type(ticket), TPMT_TK_CREATION)
         self.ectx.flush_context(handle)
 
-        handle, _, _, _, _ = self.ectx.create_primary(inSensitive,)
+        handle, _, _, _, _ = self.ectx.create_primary(inSensitive)
         self.assertNotEqual(handle, 0)
         self.ectx.flush_context(handle)
 
@@ -82,7 +82,7 @@ class TestEsys(TSS2_EsapiTest):
 
         with self.assertRaises(TypeError):
             self.ectx.create_primary(
-                TPM2B_DATA, inPublic, ESYS_TR.OWNER, outsideInfo, creationPCR,
+                TPM2B_DATA, inPublic, ESYS_TR.OWNER, outsideInfo, creationPCR
             )
 
         with self.assertRaises(TypeError):
@@ -96,17 +96,17 @@ class TestEsys(TSS2_EsapiTest):
 
         with self.assertRaises(TypeError):
             self.ectx.create_primary(
-                inSensitive, inPublic, object(), outsideInfo, creationPCR,
+                inSensitive, inPublic, object(), outsideInfo, creationPCR
             )
 
         with self.assertRaises(TypeError):
             self.ectx.create_primary(
-                inSensitive, inPublic, ESYS_TR.OWNER, object(), creationPCR,
+                inSensitive, inPublic, ESYS_TR.OWNER, object(), creationPCR
             )
 
         with self.assertRaises(TypeError):
             self.ectx.create_primary(
-                inSensitive, inPublic, ESYS_TR.OWNER, outsideInfo, TPM2B_SENSITIVE(),
+                inSensitive, inPublic, ESYS_TR.OWNER, outsideInfo, TPM2B_SENSITIVE()
             )
 
         with self.assertRaises(TypeError):
@@ -131,7 +131,7 @@ class TestEsys(TSS2_EsapiTest):
     def test_pcr_read(self):
 
         pcrsels = TPML_PCR_SELECTION.parse("sha1:3+sha256:all")
-        _, _, digests, = self.ectx.pcr_read(pcrsels)
+        _, _, digests = self.ectx.pcr_read(pcrsels)
 
         self.assertEqual(len(digests[0]), 20)
 
@@ -1146,7 +1146,7 @@ class TestEsys(TSS2_EsapiTest):
             self.ectx.zgen_2_phase(eccHandle, inQsB, inQeB, TPM2_ALG.ECDH, "baz")
 
         with self.assertRaises(ValueError):
-            self.ectx.zgen_2_phase(eccHandle, inQsB, inQeB, TPM2_ALG.ECDH, 2 ** 18)
+            self.ectx.zgen_2_phase(eccHandle, inQsB, inQeB, TPM2_ALG.ECDH, 2**18)
 
         with self.assertRaises(TypeError):
             self.ectx.zgen_2_phase(
@@ -2497,7 +2497,7 @@ class TestEsys(TSS2_EsapiTest):
 
         with self.assertRaises(TSS2_Exception) as e:
             self.ectx.field_upgrade_start(
-                keyhandle, b"", TPMT_SIGNATURE(sigAlg=TPM2_ALG.NULL),
+                keyhandle, b"", TPMT_SIGNATURE(sigAlg=TPM2_ALG.NULL)
             )
         self.assertEqual(e.exception.error, TPM2_RC.COMMAND_CODE)
 
@@ -2602,7 +2602,7 @@ class TestEsys(TSS2_EsapiTest):
 
         inSensitive = TPM2B_SENSITIVE_CREATE()
 
-        primary1, _, _, _, _ = self.ectx.create_primary(inSensitive, inPublic,)
+        primary1, _, _, _, _ = self.ectx.create_primary(inSensitive, inPublic)
 
         primary2, _, _, _, _ = self.ectx.create_primary(inSensitive, inPublic)
 
@@ -2938,7 +2938,7 @@ class TestEsys(TSS2_EsapiTest):
         self.ectx.policy_auth_value(session)
         self.ectx.policy_command_code(session, TPM2_CC.Duplicate)
 
-        sym = TPMT_SYM_DEF_OBJECT(algorithm=TPM2_ALG.NULL,)
+        sym = TPMT_SYM_DEF_OBJECT(algorithm=TPM2_ALG.NULL)
 
         encryptionKey, duplicate, symSeed = self.ectx.duplicate(
             childHandle, primary2, None, sym, session1=session
@@ -3063,7 +3063,7 @@ class TestEsys(TSS2_EsapiTest):
 
         signHandle = self.ectx.create_primary(inSensitive, inPublic)[0]
 
-        sym = TPMT_SYM_DEF(algorithm=TPM2_ALG.NULL,)
+        sym = TPMT_SYM_DEF(algorithm=TPM2_ALG.NULL)
 
         session = self.ectx.start_auth_session(
             tpm_key=ESYS_TR.NONE,

--- a/test/test_policy.py
+++ b/test/test_policy.py
@@ -485,7 +485,7 @@ class TestPolicy(TSS2_EsapiTest):
                         {
                             "name": "branch2",
                             "description": "branch2 description",
-                            "policy": [{"type": "locality", "locality": ["zero",]}],
+                            "policy": [{"type": "locality", "locality": ["zero"]}],
                         },
                     ],
                 },
@@ -663,7 +663,7 @@ class TestPolicy(TSS2_EsapiTest):
                 sigAlg=TPM2_ALG.ECDSA,
                 signature=TPMU_SIGNATURE(
                     ecdsa=TPMS_SIGNATURE_ECC(
-                        hash=TPM2_ALG.SHA256, signatureR=rb, signatureS=sb,
+                        hash=TPM2_ALG.SHA256, signatureR=rb, signatureS=sb
                     )
                 ),
             )

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -741,7 +741,7 @@ class TypesTest(unittest.TestCase):
         keysizes = [128, 192, 256]
         modes = ["cfb", "cbc", "ofb", "ctr", "ecb"]
 
-        for rsasize, keysize, mode, in list(
+        for rsasize, keysize, mode in list(
             itertools.product(rsasizes, keysizes, modes)
         ):
             templ = TPMT_PUBLIC.parse(
@@ -1630,7 +1630,7 @@ class TypesTest(unittest.TestCase):
         pos = +TPM2_ALG.RSA
         self.assertIsInstance(pos, TPM2_ALG)
 
-        p = TPM2_ALG.RSA ** 1
+        p = TPM2_ALG.RSA**1
         self.assertIsInstance(p, TPM2_ALG)
 
         radd = 1 + TPM2_ALG.NULL
@@ -1655,7 +1655,7 @@ class TypesTest(unittest.TestCase):
         r = round(TPM2_ALG.RSA)
         self.assertIsInstance(r, TPM2_ALG)
 
-        rp = 2 ** TPM2_ALG.RSA
+        rp = 2**TPM2_ALG.RSA
         self.assertIsInstance(rp, TPM2_ALG)
 
         rrs = 1 >> TPM2_ALG.RSA
@@ -1861,7 +1861,7 @@ class TypesTest(unittest.TestCase):
         if not _lib_version_atleast("tss2-policy", "4.0.0"):
             self.skipTest("tss2-policy required")
         select = TSS2_POLICY_PCR_SELECTIONS(
-            pcr_select=TPMS_PCR_SELECT(sizeofSelect=1, pcrSelect=b"\xAA",),
+            pcr_select=TPMS_PCR_SELECT(sizeofSelect=1, pcrSelect=b"\xAA")
         )
         self.assertEqual(select.pcr_select.sizeofSelect, 1)
         self.assertEqual(bytes(select.pcr_select.pcrSelect), b"\xAA\x00\x00\x00")
@@ -1895,7 +1895,7 @@ class TypesTest(unittest.TestCase):
         s = TSS2_POLICY_PCR_SELECTION(
             type=TSS2_POLICY_PCR_SELECTOR.PCR_SELECT,
             selections=TSS2_POLICY_PCR_SELECTIONS(
-                pcr_select=TPMS_PCR_SELECT(sizeofSelect=3, pcrSelect=b"\xFF\xFF\xFF",),
+                pcr_select=TPMS_PCR_SELECT(sizeofSelect=3, pcrSelect=b"\xFF\xFF\xFF")
             ),
         )
         self.assertEqual(s.type, TSS2_POLICY_PCR_SELECTOR.PCR_SELECT)


### PR DESCRIPTION
black version 19 does not work with python 3.13 due to a dependency on typed-ast.