### PR TITLE
setup.py: Explicilty use C99 for preprocessing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -189,6 +189,7 @@ class type_generator(build_ext):
             pdata = preprocess_file(
                 header_path,
                 cpp_args=[
+                    "-std=c99",
                     "-D__builtin_va_list=char*",
                     "-D__extension__=",
                     "-D__attribute__(x)=",
@@ -196,7 +197,8 @@ class type_generator(build_ext):
             )
         else:
             pdata = preprocess_file(
-                header_path, cpp_args=["-D__extension__=", "-D__attribute__(x)="]
+                header_path,
+                cpp_args=["-std=c99", "-D__extension__=", "-D__attribute__(x)="],
             )
         parser = c_parser.CParser()
         ast = parser.parse(pdata, "tss2_tpm2_types.h")
@@ -218,6 +220,7 @@ class type_generator(build_ext):
                     pdata = preprocess_file(
                         policy_header_path,
                         cpp_args=[
+                            "-std=c99",
                             "-D__builtin_va_list=char*",
                             "-D__extension__=",
                             "-D__attribute__(x)=",
@@ -229,6 +232,7 @@ class type_generator(build_ext):
                     pdata = preprocess_file(
                         policy_header_path,
                         cpp_args=[
+                            "-std=c99",
                             "-D__extension__=",
                             "-D__attribute__(x)=",
                             "-D__float128=long double",


### PR DESCRIPTION
GCC 15 uses -std=c23 by default, which causes pycparser to error out with "pycparser.plyparser.ParseError:
/usr/lib/gcc/x86_64-pc-linux-gnu/15/include/stddef.h:450:31: before: nullptr_t". As pcyparser only supports completely C99, this shouldn't be an issue.