### PR TITLE
types: add marshal/unmarshal methods for unions.

### DIFF
--- a/src/tpm2_pytss/encoding.py
+++ b/src/tpm2_pytss/encoding.py
@@ -38,6 +38,7 @@ from .types import (
     TPMT_SIG_SCHEME,
     TPMT_RSA_DECRYPT,
     TPMT_PUBLIC_PARMS,
+    TPM_BASE_OBJECT,
 )
 
 
@@ -210,7 +211,7 @@ class base_encdec(object):
         Raises:
             TypeError: if val is either a TPM union or if type of val is unsupported.
         """
-        if isinstance(val, TPM_OBJECT) and self._is_union(val):
+        if isinstance(val, TPM_BASE_OBJECT) and self._is_union(val):
             raise TypeError(f"tried to encode union {val.__class__.__name__}")
         if isinstance(val, TPMA_FRIENDLY_INTLIST):
             return self.encode_friendly_intlist(val)
@@ -404,7 +405,7 @@ class base_encdec(object):
         Raises:
             TypeError: if dst is not a supported type or dst is a TPM union
         """
-        if isinstance(dst, TPM_OBJECT) and self._is_union(dst):
+        if isinstance(dst, TPM_BASE_OBJECT) and self._is_union(dst):
             raise TypeError(f"tried to decode union {dst.__class__.__name__}")
         if isinstance(dst, TPMA_FRIENDLY_INTLIST):
             return self.decode_friendly_intlist(dst, src)

--- a/src/tpm2_pytss/types.py
+++ b/src/tpm2_pytss/types.py
@@ -39,6 +39,7 @@ from tpm2_pytss.constants import (
     TPM2_ECC_CURVE,
     TPM2_SE,
     TPM2_HR,
+    TPM_INT_MU,
 )
 from typing import Union, Tuple, Optional
 import sys
@@ -62,42 +63,8 @@ class ParserAttributeError(Exception):
     pass
 
 
-class TPM2_HANDLE(int):
+class TPM2_HANDLE(int, TPM_INT_MU):
     """A handle to a TPM address"""
-
-    def marshal(self) -> bytes:
-        """Marshal instance into bytes.
-
-        Returns:
-            Returns the marshaled TPM2_HANDLE as bytes.
-        """
-        mfunc = getattr(lib, f"Tss2_MU_{self.__class__.__name__}_Marshal", None)
-        if mfunc is None:
-            raise RuntimeError(
-                f"No marshal function found for {self.__class__.__name__}"
-            )
-        offset = ffi.new("size_t *")
-        buf = ffi.new("uint8_t[4096]")
-        _chkrc(mfunc(int(self), buf, 4096, offset))
-        return bytes(buf[0 : offset[0]])
-
-    @classmethod
-    def unmarshal(cls, buf) -> tuple["TPM2_HANDLE", int]:
-        """Unmarshal bytes into TPM2_HANDLE.
-
-        Args:
-            buf (bytes): The bytes to be unmarshaled.
-
-        Returns:
-            Returns an instance of TPM2_HANDLE and the number of bytes consumed.
-        """
-        umfunc = getattr(lib, f"Tss2_MU_{cls.__name__}_Unmarshal", None)
-        if umfunc is None:
-            raise RuntimeError(f"No unmarshal function found for {cls.__name__}")
-        cdata = ffi.new("TPM2_HANDLE *")
-        offset = ffi.new("size_t *")
-        _chkrc(umfunc(buf, len(buf), offset, cdata))
-        return cls(cdata[0]), offset[0]
 
 
 class TPM_OBJECT(object):

--- a/src/tpm2_pytss/types.py
+++ b/src/tpm2_pytss/types.py
@@ -544,7 +544,54 @@ class TPML_OBJECT(TPM_OBJECT):
         return TPML_Iterator(self)
 
 
-class TPMU_PUBLIC_PARMS(TPM_OBJECT):
+class TPMU_OBJECT(TPM_BASE_OBJECT):
+    """Base class for union types, not suitable for direct instantiation."""
+
+    def marshal(self, selector: int) -> bytes:
+        """Marshal union instance into bytes.
+
+        Args:
+            selector (int): The union selector.
+        Returns:
+            Returns the marshaled type as bytes.
+        """
+        mfunc = getattr(lib, f"Tss2_MU_{self.__class__.__name__}_Marshal", None)
+        if mfunc is None:
+            raise RuntimeError(
+                f"No marshal function found for {self.__class__.__name__}"
+            )
+        _cdata = self._cdata
+        tipe = ffi.typeof(_cdata)
+        if tipe.kind != "pointer":
+            _cdata = ffi.new(f"{self.__class__.__name__} *", self._cdata)
+        offset = ffi.new("size_t *")
+        buf = ffi.new("uint8_t[4096]")
+        _chkrc(mfunc(_cdata, selector, buf, 4096, offset))
+        return bytes(buf[0 : offset[0]])
+
+    @classmethod
+    def unmarshal(cls, selector: int, buf: bytes):
+        """Unmarshal bytes into type instance.
+
+        Args:
+            selector (int): The union selector.
+            buf (bytes): The bytes to be unmarshaled.
+
+        Returns:
+            Returns an instance of the current type and the number of bytes consumed.
+        """
+        umfunc = getattr(lib, f"Tss2_MU_{cls.__name__}_Unmarshal", None)
+        if umfunc is None:
+            raise RuntimeError(f"No unmarshal function found for {cls.__name__}")
+        if isinstance(buf, TPM2B_SIMPLE_OBJECT):
+            buf = bytes(buf)
+        _cdata = ffi.new(f"{cls.__name__} *")
+        offset = ffi.new("size_t *")
+        _chkrc(umfunc(buf, len(buf), offset, selector, _cdata))
+        return cls(_cdata=_cdata), offset[0]
+
+
+class TPMU_PUBLIC_PARMS(TPMU_OBJECT):
     pass
 
 
@@ -1753,7 +1800,7 @@ class TPMS_ASYM_PARMS(TPM_OBJECT):
     pass
 
 
-class TPMU_ATTEST(TPM_OBJECT):
+class TPMU_ATTEST(TPMU_OBJECT):
     pass
 
 
@@ -1769,7 +1816,7 @@ class TPMS_AUTH_RESPONSE(TPM_OBJECT):
     pass
 
 
-class TPMU_CAPABILITIES(TPM_OBJECT):
+class TPMU_CAPABILITIES(TPMU_OBJECT):
     pass
 
 
@@ -2055,11 +2102,11 @@ class TPMT_ECC_SCHEME(TPM_OBJECT):
     pass
 
 
-class TPMU_ASYM_SCHEME(TPM_OBJECT):
+class TPMU_ASYM_SCHEME(TPMU_OBJECT):
     pass
 
 
-class TPMU_KDF_SCHEME(TPM_OBJECT):
+class TPMU_KDF_SCHEME(TPMU_OBJECT):
     pass
 
 
@@ -2075,11 +2122,11 @@ class TPMT_RSA_SCHEME(TPM_OBJECT):
     pass
 
 
-class TPMU_SYM_KEY_BITS(TPM_OBJECT):
+class TPMU_SYM_KEY_BITS(TPMU_OBJECT):
     pass
 
 
-class TPMU_SYM_MODE(TPM_OBJECT):
+class TPMU_SYM_MODE(TPMU_OBJECT):
     pass
 
 
@@ -2091,7 +2138,7 @@ class TPM2B_NONCE(TPM2B_SIMPLE_OBJECT):
     pass
 
 
-class TPMU_PUBLIC_ID(TPM_OBJECT):
+class TPMU_PUBLIC_ID(TPMU_OBJECT):
     pass
 
 
@@ -2270,11 +2317,11 @@ class TPMT_SENSITIVE(TPM_OBJECT):
         )
 
 
-class TPMU_SENSITIVE_COMPOSITE(TPM_OBJECT):
+class TPMU_SENSITIVE_COMPOSITE(TPMU_OBJECT):
     pass
 
 
-class TPMU_SCHEME_KEYEDHASH(TPM_OBJECT):
+class TPMU_SCHEME_KEYEDHASH(TPMU_OBJECT):
     pass
 
 
@@ -2302,7 +2349,7 @@ class TPMT_HA(TPM_OBJECT):
         return bytes(self.digest.sha512[0:ds])
 
 
-class TPMU_HA(TPM_OBJECT):
+class TPMU_HA(TPMU_OBJECT):
     pass
 
 
@@ -2310,7 +2357,7 @@ class TPMT_SIG_SCHEME(TPM_OBJECT):
     pass
 
 
-class TPMU_SIGNATURE(TPM_OBJECT):
+class TPMU_SIGNATURE(TPMU_OBJECT):
     pass
 
 
@@ -2339,7 +2386,7 @@ class TPMT_SIGNATURE(TPM_OBJECT):
         return _get_signature_bytes(self)
 
 
-class TPMU_SIG_SCHEME(TPM_OBJECT):
+class TPMU_SIG_SCHEME(TPMU_OBJECT):
     pass
 
 

--- a/src/tpm2_pytss/types.py
+++ b/src/tpm2_pytss/types.py
@@ -67,7 +67,7 @@ class TPM2_HANDLE(int, TPM_INT_MU):
     """A handle to a TPM address"""
 
 
-class TPM_OBJECT(object):
+class TPM_BASE_OBJECT(object):
     """Abstract Base class for all TPM Objects. Not suitable for direct instantiation."""
 
     def __init__(self, _cdata=None, **kwargs):
@@ -111,7 +111,7 @@ class TPM_OBJECT(object):
                     subobj = clazz(_cdata=None)
                     setattr(subobj, _bytefield, v)
                     v = subobj
-            TPM_OBJECT.__setattr__(self, k, v)
+            TPM_BASE_OBJECT.__setattr__(self, k, v)
 
     def __getattribute__(self, key):
         try:
@@ -140,7 +140,7 @@ class TPM_OBJECT(object):
 
         _value = value
         _cdata = object.__getattribute__(self, "_cdata")
-        if isinstance(value, TPM_OBJECT):
+        if isinstance(value, TPM_BASE_OBJECT):
             tipe = ffi.typeof(value._cdata)
             if tipe.kind in ["struct", "union"]:
                 value = value._cdata
@@ -200,6 +200,10 @@ class TPM_OBJECT(object):
 
     def __dir__(self):
         return object.__dir__(self) + dir(self._cdata)
+
+
+class TPM_OBJECT(TPM_BASE_OBJECT):
+    """Base class struct types, not suitable for direct instantiation."""
 
     def marshal(self):
         """Marshal instance into bytes.

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -2030,6 +2030,28 @@ class TypesTest(unittest.TestCase):
         self.assertEqual(handle, 0xFFFFFFFF)
         self.assertEqual(off, 4)
 
+    def test_union_marshal(self):
+        dig = b"A" * 32
+        ha = TPMU_HA(sha256=dig)
+        buf = ha.marshal(TPM2_ALG.SHA256)
+
+        self.assertEqual(buf, dig)
+
+        with self.assertRaises(TSS2_Exception) as e:
+            ha.marshal(TPM2_ALG.LAST + 1)
+        self.assertEqual(e.exception.rc, TSS2_RC.MU_RC_BAD_VALUE)
+
+    def test_union_unmarshal(self):
+        dig = b"A" * 32
+        ha, off = TPMU_HA.unmarshal(TPM2_ALG.SHA256, dig)
+
+        self.assertEqual(bytes(ha.sha256), dig)
+        self.assertEqual(off, len(dig))
+
+        with self.assertRaises(TSS2_Exception) as e:
+            ha.unmarshal(TPM2_ALG.LAST + 1, dig)
+        self.assertEqual(e.exception.rc, TSS2_RC.MU_RC_BAD_VALUE)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
To marshal/unmarshal an union a selector is needed. So add methods which takes the selector as an argument.

Closes #651