### PR TITLE
utils: refactor EK template handling.

### DIFF
--- a/src/tpm2_pytss/internal/templates.py
+++ b/src/tpm2_pytss/internal/templates.py
@@ -1,4 +1,5 @@
-from collections import namedtuple
+# SPDX-License-Identifier: BSD-2
+
 from ..types import (
     TPMT_SYM_DEF_OBJECT,
     TPMU_SYM_KEY_BITS,
@@ -13,22 +14,18 @@ from ..types import (
     TPMT_ECC_SCHEME,
     TPMT_KDF_SCHEME,
     TPMS_ECC_POINT,
+    TPM2_HANDLE,
 )
 from ..constants import (
     TPM2_ALG,
     TPMA_OBJECT,
     TPM2_ECC,
 )
+from typing import ClassVar, Optional, Sequence
 
 
-class _ek:
-    _ek_tuple = namedtuple("_ek_tuple", ["cert_index", "ek_template"])
-    _low_symmetric = TPMT_SYM_DEF_OBJECT(
-        algorithm=TPM2_ALG.AES,
-        keyBits=TPMU_SYM_KEY_BITS(aes=128),
-        mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
-    )
-    _low_attrs = (
+class template_attributes:
+    low = (
         TPMA_OBJECT.FIXEDTPM
         | TPMA_OBJECT.FIXEDPARENT
         | TPMA_OBJECT.SENSITIVEDATAORIGIN
@@ -36,41 +33,7 @@ class _ek:
         | TPMA_OBJECT.RESTRICTED
         | TPMA_OBJECT.DECRYPT
     )
-    _low_policy = b"\x83q\x97gD\x84\xb3\xf8\x1a\x90\xcc\x8dF\xa5\xd7$\xfdR\xd7n\x06R\x0bd\xf2\xa1\xda\x1b3\x14i\xaa"
-    _ek_rsa2048_template = TPM2B_PUBLIC(
-        publicArea=TPMT_PUBLIC(
-            type=TPM2_ALG.RSA,
-            nameAlg=TPM2_ALG.SHA256,
-            objectAttributes=_low_attrs,
-            authPolicy=_low_policy,
-            parameters=TPMU_PUBLIC_PARMS(
-                rsaDetail=TPMS_RSA_PARMS(
-                    symmetric=_low_symmetric,
-                    scheme=TPMT_RSA_SCHEME(scheme=TPM2_ALG.NULL),
-                    keyBits=2048,
-                ),
-            ),
-            unique=TPMU_PUBLIC_ID(rsa=b"\x00" * 256),
-        )
-    )
-    _ek_ecc256_template = TPM2B_PUBLIC(
-        publicArea=TPMT_PUBLIC(
-            type=TPM2_ALG.ECC,
-            nameAlg=TPM2_ALG.SHA256,
-            objectAttributes=_low_attrs,
-            authPolicy=_low_policy,
-            parameters=TPMU_PUBLIC_PARMS(
-                eccDetail=TPMS_ECC_PARMS(
-                    symmetric=_low_symmetric,
-                    scheme=TPMT_ECC_SCHEME(scheme=TPM2_ALG.NULL),
-                    curveID=TPM2_ECC.NIST_P256,
-                    kdf=TPMT_KDF_SCHEME(scheme=TPM2_ALG.NULL),
-                )
-            ),
-            unique=TPMU_PUBLIC_ID(ecc=TPMS_ECC_POINT(x=b"\x00" * 32, y=b"\x00" * 32)),
-        )
-    )
-    _high_attrs = (
+    high = (
         TPMA_OBJECT.FIXEDTPM
         | TPMA_OBJECT.FIXEDPARENT
         | TPMA_OBJECT.SENSITIVEDATAORIGIN
@@ -79,44 +42,130 @@ class _ek:
         | TPMA_OBJECT.RESTRICTED
         | TPMA_OBJECT.DECRYPT
     )
-    _256_symmetric = TPMT_SYM_DEF_OBJECT(
+
+
+class template_policy:
+    low = b"\x83q\x97gD\x84\xb3\xf8\x1a\x90\xcc\x8dF\xa5\xd7$\xfdR\xd7n\x06R\x0bd\xf2\xa1\xda\x1b3\x14i\xaa"
+    sha256 = b"\xca=\n\x99\xa2\xb99\x06\xf7\xa34$\x14\xef\xcf\xb3\xa3\x85\xd4L\xd1\xfdE\x90\x89\xd1\x9bPq\xc0\xb7\xa0"
+    sha384 = b"\xb2n}(\xd1\x1aP\xbcS\xd8\x82\xbc\xf5\xfd:\x1a\x07AH\xbb5\xd3\xb4\xe4\xcb\x1c\n\xd9\xbd\xe4\x19\xca\xcbG\xba\ti\x96F\x15\x0f\x9f\xc0\x00\xf3\xf8\x0e\x12"
+    sha512 = b'\xb8"\x1c\xa6\x9e\x85P\xa4\x91M\xe3\xfa\xa6\xa1\x8c\x07,\xc0\x12\x08\x07:\x92\x8d]f\xd5\x9e\xf7\x9eI\xa4)\xc4\x1ak&\x95q\xd5~\xdb%\xfb\xdb\x188BV\x08\xb4\x13\xcdaj_m\xb5\xb6\x07\x1a\xf9\x9b\xea'
+    sm3_256 = b"\x16x`\xa3_,\\5g\xf9\xc9'\xacV\xc02\xf3\xb3\xa6F/\x8d\x03y\x98\xe7\xa1\x0fw\xfaEJ"
+
+
+class template_symmetric:
+    low = TPMT_SYM_DEF_OBJECT(
+        algorithm=TPM2_ALG.AES,
+        keyBits=TPMU_SYM_KEY_BITS(aes=128),
+        mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
+    )
+    aes256 = TPMT_SYM_DEF_OBJECT(
         algorithm=TPM2_ALG.AES,
         keyBits=TPMU_SYM_KEY_BITS(aes=256),
         mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
     )
-    _sm4_symmetric = TPMT_SYM_DEF_OBJECT(
+    sm4 = TPMT_SYM_DEF_OBJECT(
         algorithm=TPM2_ALG.SM4,
         keyBits=TPMU_SYM_KEY_BITS(sm4=128),
         mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
     )
-    _sha256_policy = b"\xca=\n\x99\xa2\xb99\x06\xf7\xa34$\x14\xef\xcf\xb3\xa3\x85\xd4L\xd1\xfdE\x90\x89\xd1\x9bPq\xc0\xb7\xa0"
-    _sha384_policy = b"\xb2n}(\xd1\x1aP\xbcS\xd8\x82\xbc\xf5\xfd:\x1a\x07AH\xbb5\xd3\xb4\xe4\xcb\x1c\n\xd9\xbd\xe4\x19\xca\xcbG\xba\ti\x96F\x15\x0f\x9f\xc0\x00\xf3\xf8\x0e\x12"
-    _sha512_policy = b'\xb8"\x1c\xa6\x9e\x85P\xa4\x91M\xe3\xfa\xa6\xa1\x8c\x07,\xc0\x12\x08\x07:\x92\x8d]f\xd5\x9e\xf7\x9eI\xa4)\xc4\x1ak&\x95q\xd5~\xdb%\xfb\xdb\x188BV\x08\xb4\x13\xcdaj_m\xb5\xb6\x07\x1a\xf9\x9b\xea'
-    _sm3_256_policy = b"\x16x`\xa3_,\\5g\xf9\xc9'\xacV\xc02\xf3\xb3\xa6F/\x8d\x03y\x98\xe7\xa1\x0fw\xfaEJ"
-    _ek_high_rsa2048_template = TPM2B_PUBLIC(
+
+
+class ek_template:
+    cert_index: ClassVar[TPM2_HANDLE]
+    nonce_index: ClassVar[Optional[TPM2_HANDLE]] = None
+    template: ClassVar[TPM2B_PUBLIC]
+    _templates: ClassVar[dict[str, type["ek_template"]]] = dict()
+    _names: ClassVar[Sequence[str]]
+
+    def __init_subclass__(cls):
+        for name in cls._names:
+            name = name.lower()
+            ek_template._templates[name] = cls
+
+    @classmethod
+    def lookup(cls, name: str) -> "ek_template":
+        name = name.lower()
+        template = cls._templates.get(name, None)
+        return template
+
+
+class ek_rsa2048(ek_template):
+    _names = ("EK-RSA2048", "L-1")
+    cert_index = TPM2_HANDLE(0x01C00002)
+    nonce_index = cert_index + 1
+    template = TPM2B_PUBLIC(
         publicArea=TPMT_PUBLIC(
             type=TPM2_ALG.RSA,
             nameAlg=TPM2_ALG.SHA256,
-            objectAttributes=_high_attrs,
-            authPolicy=_sha256_policy,
+            objectAttributes=template_attributes.low,
+            authPolicy=template_policy.low,
             parameters=TPMU_PUBLIC_PARMS(
                 rsaDetail=TPMS_RSA_PARMS(
-                    symmetric=_low_symmetric,
+                    symmetric=template_symmetric.low,
+                    scheme=TPMT_RSA_SCHEME(scheme=TPM2_ALG.NULL),
+                    keyBits=2048,
+                ),
+            ),
+            unique=TPMU_PUBLIC_ID(rsa=b"\x00" * 256),
+        )
+    )
+
+
+class ek_ecc256(ek_template):
+    _names = ("EK-ECC256", "L-2")
+    cert_index = TPM2_HANDLE(0x01C0000A)
+    nonce_index = cert_index + 1
+    template = TPM2B_PUBLIC(
+        publicArea=TPMT_PUBLIC(
+            type=TPM2_ALG.ECC,
+            nameAlg=TPM2_ALG.SHA256,
+            objectAttributes=template_attributes.low,
+            authPolicy=template_policy.low,
+            parameters=TPMU_PUBLIC_PARMS(
+                eccDetail=TPMS_ECC_PARMS(
+                    symmetric=template_symmetric.low,
+                    scheme=TPMT_ECC_SCHEME(scheme=TPM2_ALG.NULL),
+                    curveID=TPM2_ECC.NIST_P256,
+                    kdf=TPMT_KDF_SCHEME(scheme=TPM2_ALG.NULL),
+                )
+            ),
+            unique=TPMU_PUBLIC_ID(ecc=TPMS_ECC_POINT(x=b"\x00" * 32, y=b"\x00" * 32)),
+        )
+    )
+
+
+class ek_high_rsa2048(ek_template):
+    _names = ("EK-HIGH-RSA2048", "H-1")
+    cert_index = TPM2_HANDLE(0x01C00012)
+    template = TPM2B_PUBLIC(
+        publicArea=TPMT_PUBLIC(
+            type=TPM2_ALG.RSA,
+            nameAlg=TPM2_ALG.SHA256,
+            objectAttributes=template_attributes.high,
+            authPolicy=template_policy.sha256,
+            parameters=TPMU_PUBLIC_PARMS(
+                rsaDetail=TPMS_RSA_PARMS(
+                    symmetric=template_symmetric.low,
                     scheme=TPMT_RSA_SCHEME(scheme=TPM2_ALG.NULL),
                     keyBits=2048,
                 ),
             ),
         )
     )
-    _ek_high_ecc256_template = TPM2B_PUBLIC(
+
+
+class ek_high_ecc256(ek_template):
+    _names = ("EK-HIGH-ECC256", "H-2")
+    cert_index = TPM2_HANDLE(0x01C00014)
+    template = TPM2B_PUBLIC(
         publicArea=TPMT_PUBLIC(
             type=TPM2_ALG.ECC,
             nameAlg=TPM2_ALG.SHA256,
-            objectAttributes=_high_attrs,
-            authPolicy=_sha256_policy,
+            objectAttributes=template_attributes.high,
+            authPolicy=template_policy.sha256,
             parameters=TPMU_PUBLIC_PARMS(
                 eccDetail=TPMS_ECC_PARMS(
-                    symmetric=_low_symmetric,
+                    symmetric=template_symmetric.low,
                     scheme=TPMT_ECC_SCHEME(scheme=TPM2_ALG.NULL),
                     curveID=TPM2_ECC.NIST_P256,
                     kdf=TPMT_KDF_SCHEME(scheme=TPM2_ALG.NULL),
@@ -124,15 +173,20 @@ class _ek:
             ),
         ),
     )
-    _ek_high_ecc384_template = TPM2B_PUBLIC(
+
+
+class ek_high_ecc384(ek_template):
+    _names = ("EK-HIGH-ECC384", "H-3")
+    cert_index = TPM2_HANDLE(0x01C00016)
+    template = TPM2B_PUBLIC(
         publicArea=TPMT_PUBLIC(
             type=TPM2_ALG.ECC,
             nameAlg=TPM2_ALG.SHA384,
-            objectAttributes=_high_attrs,
-            authPolicy=_sha384_policy,
+            objectAttributes=template_attributes.high,
+            authPolicy=template_policy.sha384,
             parameters=TPMU_PUBLIC_PARMS(
                 eccDetail=TPMS_ECC_PARMS(
-                    symmetric=_256_symmetric,
+                    symmetric=template_symmetric.aes256,
                     scheme=TPMT_ECC_SCHEME(scheme=TPM2_ALG.NULL),
                     curveID=TPM2_ECC.NIST_P384,
                     kdf=TPMT_KDF_SCHEME(scheme=TPM2_ALG.NULL),
@@ -140,15 +194,20 @@ class _ek:
             ),
         ),
     )
-    _ek_high_ecc521_template = TPM2B_PUBLIC(
+
+
+class ek_high_ecc521(ek_template):
+    _names = ("EK-HIGH-ECC521", "H-4")
+    cert_index = TPM2_HANDLE(0x01C00018)
+    template = TPM2B_PUBLIC(
         publicArea=TPMT_PUBLIC(
             type=TPM2_ALG.ECC,
             nameAlg=TPM2_ALG.SHA512,
-            objectAttributes=_high_attrs,
-            authPolicy=_sha512_policy,
+            objectAttributes=template_attributes.high,
+            authPolicy=template_policy.sha512,
             parameters=TPMU_PUBLIC_PARMS(
                 eccDetail=TPMS_ECC_PARMS(
-                    symmetric=_256_symmetric,
+                    symmetric=template_symmetric.aes256,
                     scheme=TPMT_ECC_SCHEME(scheme=TPM2_ALG.NULL),
                     curveID=TPM2_ECC.NIST_P521,
                     kdf=TPMT_KDF_SCHEME(scheme=TPM2_ALG.NULL),
@@ -156,15 +215,20 @@ class _ek:
             ),
         ),
     )
-    _ek_high_eccsm2p521_template = TPM2B_PUBLIC(
+
+
+class ek_high_ecc_sm2_p256(ek_template):
+    _names = ("EK-HIGH-ECCSM2P256", "H-5")
+    cert_index = TPM2_HANDLE(0x01C0001A)
+    template = TPM2B_PUBLIC(
         publicArea=TPMT_PUBLIC(
             type=TPM2_ALG.ECC,
             nameAlg=TPM2_ALG.SM3_256,
-            objectAttributes=_high_attrs,
-            authPolicy=_sm3_256_policy,
+            objectAttributes=template_attributes.high,
+            authPolicy=template_policy.sm3_256,
             parameters=TPMU_PUBLIC_PARMS(
                 eccDetail=TPMS_ECC_PARMS(
-                    symmetric=_sm4_symmetric,
+                    symmetric=template_symmetric.sm4,
                     scheme=TPMT_ECC_SCHEME(scheme=TPM2_ALG.NULL),
                     curveID=TPM2_ECC.SM2_P256,
                     kdf=TPMT_KDF_SCHEME(scheme=TPM2_ALG.NULL),
@@ -172,30 +236,20 @@ class _ek:
             ),
         ),
     )
-    _ek_high_rsa3072_template = TPM2B_PUBLIC(
+
+
+class ek_high_rsa3072(ek_template):
+    _names = ("EK-HIGH-RSA3072", "H-6")
+    cert_index = TPM2_HANDLE(0x01C0001C)
+    template = TPM2B_PUBLIC(
         publicArea=TPMT_PUBLIC(
             type=TPM2_ALG.RSA,
             nameAlg=TPM2_ALG.SHA384,
-            objectAttributes=_high_attrs,
-            authPolicy=_sha384_policy,
+            objectAttributes=template_attributes.high,
+            authPolicy=template_policy.sha384,
             parameters=TPMU_PUBLIC_PARMS(
                 rsaDetail=TPMS_RSA_PARMS(
-                    symmetric=_256_symmetric,
-                    scheme=TPMT_RSA_SCHEME(scheme=TPM2_ALG.NULL),
-                    keyBits=3072,
-                ),
-            ),
-        )
-    )
-    _ek_high_rsa4096_template = TPM2B_PUBLIC(
-        publicArea=TPMT_PUBLIC(
-            type=TPM2_ALG.RSA,
-            nameAlg=TPM2_ALG.SHA384,
-            objectAttributes=_high_attrs,
-            authPolicy=_sha384_policy,
-            parameters=TPMU_PUBLIC_PARMS(
-                rsaDetail=TPMS_RSA_PARMS(
-                    symmetric=_256_symmetric,
+                    symmetric=template_symmetric.aes256,
                     scheme=TPMT_RSA_SCHEME(scheme=TPM2_ALG.NULL),
                     keyBits=3072,
                 ),
@@ -203,12 +257,22 @@ class _ek:
         )
     )
 
-    EK_RSA2048 = _ek_tuple(0x01C00002, _ek_rsa2048_template)
-    EK_ECC256 = _ek_tuple(0x01C0000A, _ek_ecc256_template)
-    EK_HIGH_RSA2048 = _ek_tuple(0x01C00012, _ek_high_rsa2048_template)
-    EK_HIGH_ECC256 = _ek_tuple(0x01C00014, _ek_high_ecc256_template)
-    EK_HIGH_ECC384 = _ek_tuple(0x01C00016, _ek_high_ecc384_template)
-    EK_HIGH_ECC521 = _ek_tuple(0x01C00018, _ek_high_ecc521_template)
-    EK_HIGH_ECCSM2P521 = _ek_tuple(0x01C0001A, _ek_high_eccsm2p521_template)
-    EK_HIGH_RSA3072 = _ek_tuple(0x01C0001C, _ek_high_rsa3072_template)
-    EK_HIGH_RSA4096 = _ek_tuple(0x01C0001E, _ek_high_rsa4096_template)
+
+class ek_high_rsa4096(ek_template):
+    _names = ("EK-HIGH-RSA4096", "H-7")
+    cert_index = TPM2_HANDLE(0x01C0001E)
+    template = TPM2B_PUBLIC(
+        publicArea=TPMT_PUBLIC(
+            type=TPM2_ALG.RSA,
+            nameAlg=TPM2_ALG.SHA384,
+            objectAttributes=template_attributes.high,
+            authPolicy=template_policy.sha384,
+            parameters=TPMU_PUBLIC_PARMS(
+                rsaDetail=TPMS_RSA_PARMS(
+                    symmetric=template_symmetric.aes256,
+                    scheme=TPMT_RSA_SCHEME(scheme=TPM2_ALG.NULL),
+                    keyBits=4096,
+                ),
+            ),
+        )
+    )

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -10,7 +10,7 @@ from tpm2_pytss.internal.crypto import (
     _get_digest,
 )
 from tpm2_pytss.utils import *
-from tpm2_pytss.internal.templates import _ek
+from tpm2_pytss.internal.templates import ek_template
 from .TSS2_BaseTest import TSS2_EsapiTest
 
 from cryptography.hazmat.primitives import hashes
@@ -616,10 +616,10 @@ class TestUtils(TSS2_EsapiTest):
             create_ek_template("EK-HIGH-RSA2048", nv_read)
         self.assertEqual(str(e.exception), "no certificate found for EK-HIGH-RSA2048")
 
-        cert_index, def_template = _ek.EK_HIGH_RSA2048
+        template = ek_template.lookup("h-1")
         nv_cert = TPM2B_NV_PUBLIC(
             nvPublic=TPMS_NV_PUBLIC(
-                nvIndex=cert_index,
+                nvIndex=template.cert_index,
                 nameAlg=TPM2_ALG.SHA256,
                 attributes=TPMA_NV.AUTHWRITE | TPMA_NV.AUTHREAD,
                 dataSize=len(b"I am a certificate"),
@@ -628,14 +628,14 @@ class TestUtils(TSS2_EsapiTest):
         cnh = self.ectx.nv_define_space(b"", nv_cert, ESYS_TR.OWNER)
         self.ectx.nv_write(cnh, b"I am a certificate")
         nv_read = NVReadEK(self.ectx)
-        cert, template = create_ek_template("EK-HIGH-RSA2048", nv_read)
+        cert, key_template = create_ek_template("EK-HIGH-RSA2048", nv_read)
         self.assertEqual(cert, b"I am a certificate")
-        self.assertEqual(template.marshal(), def_template.marshal())
+        self.assertEqual(key_template.marshal(), template.template.marshal())
 
         tb = ek_test_template.marshal()
         nv_template = TPM2B_NV_PUBLIC(
             nvPublic=TPMS_NV_PUBLIC(
-                nvIndex=cert_index + 1,
+                nvIndex=template.cert_index + 1,
                 nameAlg=TPM2_ALG.SHA256,
                 attributes=TPMA_NV.AUTHWRITE | TPMA_NV.AUTHREAD,
                 dataSize=len(tb),
@@ -656,10 +656,10 @@ class TestUtils(TSS2_EsapiTest):
             create_ek_template("EK-HIGH-ECC256", nv_read)
         self.assertEqual(str(e.exception), "no certificate found for EK-HIGH-ECC256")
 
-        cert_index, def_template = _ek.EK_HIGH_ECC256
+        template = ek_template.lookup("H-2")
         nv_cert = TPM2B_NV_PUBLIC(
             nvPublic=TPMS_NV_PUBLIC(
-                nvIndex=cert_index,
+                nvIndex=template.cert_index,
                 nameAlg=TPM2_ALG.SHA256,
                 attributes=TPMA_NV.AUTHWRITE | TPMA_NV.AUTHREAD,
                 dataSize=len(b"I am a certificate"),
@@ -668,14 +668,14 @@ class TestUtils(TSS2_EsapiTest):
         cnh = self.ectx.nv_define_space(b"", nv_cert, ESYS_TR.OWNER)
         self.ectx.nv_write(cnh, b"I am a certificate")
         nv_read = NVReadEK(self.ectx)
-        cert, template = create_ek_template("EK-HIGH-ECC256", nv_read)
+        cert, key_template = create_ek_template("EK-HIGH-ECC256", nv_read)
         self.assertEqual(cert, b"I am a certificate")
-        self.assertEqual(template.marshal(), def_template.marshal())
+        self.assertEqual(key_template.marshal(), template.template.marshal())
 
         tb = ek_test_template.marshal()
         nv_template = TPM2B_NV_PUBLIC(
             nvPublic=TPMS_NV_PUBLIC(
-                nvIndex=cert_index + 1,
+                nvIndex=template.cert_index + 1,
                 nameAlg=TPM2_ALG.SHA256,
                 attributes=TPMA_NV.AUTHWRITE | TPMA_NV.AUTHREAD,
                 dataSize=len(tb),
@@ -684,10 +684,10 @@ class TestUtils(TSS2_EsapiTest):
         tnh = self.ectx.nv_define_space(b"", nv_template, ESYS_TR.OWNER)
         self.ectx.nv_write(tnh, tb)
         nv_read = NVReadEK(self.ectx)
-        cert, template = create_ek_template("EK-HIGH-ECC256", nv_read)
+        cert, key_template = create_ek_template("EK-HIGH-ECC256", nv_read)
         self.assertEqual(cert, b"I am a certificate")
         self.assertEqual(
-            template.marshal(), TPM2B_PUBLIC(publicArea=ek_test_template).marshal()
+            key_template.marshal(), TPM2B_PUBLIC(publicArea=ek_test_template).marshal()
         )
 
     def test_create_ek_high_ecc384(self):
@@ -696,10 +696,10 @@ class TestUtils(TSS2_EsapiTest):
             create_ek_template("EK-HIGH-ECC384", nv_read)
         self.assertEqual(str(e.exception), "no certificate found for EK-HIGH-ECC384")
 
-        cert_index, def_template = _ek.EK_HIGH_ECC384
+        template = ek_template.lookup("EK-HIGH-ECC384")
         nv_cert = TPM2B_NV_PUBLIC(
             nvPublic=TPMS_NV_PUBLIC(
-                nvIndex=cert_index,
+                nvIndex=template.cert_index,
                 nameAlg=TPM2_ALG.SHA256,
                 attributes=TPMA_NV.AUTHWRITE | TPMA_NV.AUTHREAD,
                 dataSize=len(b"I am a certificate"),
@@ -708,14 +708,14 @@ class TestUtils(TSS2_EsapiTest):
         cnh = self.ectx.nv_define_space(b"", nv_cert, ESYS_TR.OWNER)
         self.ectx.nv_write(cnh, b"I am a certificate")
         nv_read = NVReadEK(self.ectx)
-        cert, template = create_ek_template("EK-HIGH-ECC384", nv_read)
+        cert, key_template = create_ek_template("EK-HIGH-ECC384", nv_read)
         self.assertEqual(cert, b"I am a certificate")
-        self.assertEqual(template.marshal(), def_template.marshal())
+        self.assertEqual(key_template.marshal(), template.template.marshal())
 
         tb = ek_test_template.marshal()
         nv_template = TPM2B_NV_PUBLIC(
             nvPublic=TPMS_NV_PUBLIC(
-                nvIndex=cert_index + 1,
+                nvIndex=template.cert_index + 1,
                 nameAlg=TPM2_ALG.SHA256,
                 attributes=TPMA_NV.AUTHWRITE | TPMA_NV.AUTHREAD,
                 dataSize=len(tb),
@@ -724,10 +724,10 @@ class TestUtils(TSS2_EsapiTest):
         tnh = self.ectx.nv_define_space(b"", nv_template, ESYS_TR.OWNER)
         self.ectx.nv_write(tnh, tb)
         nv_read = NVReadEK(self.ectx)
-        cert, template = create_ek_template("EK-HIGH-ECC384", nv_read)
+        cert, key_template = create_ek_template("EK-HIGH-ECC384", nv_read)
         self.assertEqual(cert, b"I am a certificate")
         self.assertEqual(
-            template.marshal(), TPM2B_PUBLIC(publicArea=ek_test_template).marshal()
+            key_template.marshal(), TPM2B_PUBLIC(publicArea=ek_test_template).marshal()
         )
 
     def test_unmarshal_tools_pcr_values(self):


### PR DESCRIPTION
Clean up the code and make it more readable.
Support multiple names for different templates (EK-*, L-* and H-*). Add missing license header.
Fix the issue where EK-HIGH-RSA4096 had the wrong key size.

Closes #653