### PR TITLE
Do not require wheel for building

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=44", "wheel", "setuptools_scm[toml]>=3.4.3", "pycparser", "pkgconfig"]
+requires = ["setuptools>=44", "setuptools_scm[toml]>=3.4.3", "pycparser", "pkgconfig"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
 - current version of setuptools (70.1+) does not need wheel at all
 - older versions of setuptools would fetch wheel when building wheels (but not sdists)
