### PR TITLE
Restore environment when exiting FAPIConfig context

### DIFF
--- a/src/tpm2_pytss/FAPI.py
+++ b/src/tpm2_pytss/FAPI.py
@@ -110,7 +110,10 @@ class FAPIConfig(contextlib.ExitStack):
     def __exit__(self, exc_type, exc_val, exc_tb):
         super().__exit__(exc_type, exc_val, exc_tb)
 
-        del os.environ[FAPI_CONFIG_ENV]
+        if self.config_env_backup is not None:
+            os.environ[FAPI_CONFIG_ENV] = self.config_env_backup
+        else:
+            del os.environ[FAPI_CONFIG_ENV]
 
         if self.config_tmp_path is not None:
             os.unlink(self.config_tmp_path)


### PR DESCRIPTION
The FAPIConfig context manager was not restoring environment variables to the state prior to entering the context. A consequence of that was that it was not possible to specify a config file using the TSS2_FAPICONF environment variable while running tests. The first test would use it, but then the variable would be cleared for subsequent tests, and it would revert back to trying the default paths.