### PR TITLE
types: add equal dunder for struct-based types

### DIFF
--- a/src/tpm2_pytss/types.py
+++ b/src/tpm2_pytss/types.py
@@ -245,6 +245,13 @@ class TPM_OBJECT(TPM_BASE_OBJECT):
         _chkrc(umfunc(buf, len(buf), offset, _cdata))
         return cls(_cdata=_cdata), offset[0]
 
+    def __eq__(self, other: "TPM_OBJECT") -> bool:
+        if not isinstance(other, self.__class__):
+            return False
+        self_bytes = self.marshal()
+        other_bytes = other.marshal()
+        return self_bytes == other_bytes
+
 
 class TPM2B_SIMPLE_OBJECT(TPM_OBJECT):
     """Abstract Base class for all TPM2B Simple Objects. A Simple object contains only

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -2052,6 +2052,45 @@ class TypesTest(unittest.TestCase):
             ha.unmarshal(TPM2_ALG.LAST + 1, dig)
         self.assertEqual(e.exception.rc, TSS2_RC.MU_RC_BAD_VALUE)
 
+    def test_struct_equal(self):
+        sel_one = TPMS_PCR_SELECTION(
+            hash=TPM2_ALG.SHA1,
+            sizeofSelect=3,
+            pcrSelect=b"\xFF\xFF\xFF",
+        )
+        sel_two = TPMS_PCR_SELECTION(
+            hash=TPM2_ALG.SHA1,
+            sizeofSelect=3,
+            pcrSelect=b"\xFF\xFF\xFF",
+        )
+        self.assertEqual(sel_one, sel_two)
+
+    def test_struct_not_equal(self):
+        sel_one = TPMS_PCR_SELECTION(
+            hash=TPM2_ALG.SHA1,
+            sizeofSelect=3,
+            pcrSelect=b"\xFF\xFF\xFF",
+        )
+        sel_two = TPMS_PCR_SELECTION(
+            hash=TPM2_ALG.SHA1,
+            sizeofSelect=3,
+            pcrSelect=b"\xFF\xAA\xFF",
+        )
+        self.assertNotEqual(sel_one, sel_two)
+
+    def test_struct_not_equal_different_types(self):
+        ticket_one = TPMT_TK_AUTH(
+            tag=TPM2_ST.NULL,
+            hierarchy=TPM2_RH.NULL,
+            digest=b"falafel",
+        )
+        ticket_two = TPMT_TK_VERIFIED(
+            tag=TPM2_ST.NULL,
+            hierarchy=TPM2_RH.NULL,
+            digest=b"falafel",
+        )
+        self.assertNotEqual(ticket_one, ticket_two)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Allow comparing two stuctures by checking the output from marshal(). Only for structures as TPM2B_SIMPLE_OBJECT already has the equal dunder and unions would require a selector.

Closes #632