### PR TITLE
ci: fix pypi publishing workflow

### DIFF
--- a/.github/workflows/publish_pkg.yaml
+++ b/.github/workflows/publish_pkg.yaml
@@ -7,19 +7,19 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v2
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.x
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.x
 
     - name: Install Dependencies
       env:
-        TPM2_TSS_VERSION: 3.0.0
+        TPM2_TSS_VERSION: 4.1.3
       run: |
         python3 -m pip install --user --upgrade pip
         python3 -m pip install --user --upgrade twine


### PR DESCRIPTION
ubuntu-20.04 is no longer available, so use the same values as for the coverage workflow.