### PR TITLE
ci: test against python 3.14 and drop 3.9

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
         tss-version: ['master', '3.2.3', '4.0.2', '4.1.3']
         with-fapi: [true]
         include:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         tss-version: ['master', '3.2.3', '4.0.2', '4.1.3']
         with-fapi: [true]
         include:
-          - python-version: '3.9'
+          - python-version: '3.14'
             tss-version: '3.2.3'
             with-fapi: false
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,7 @@ Supported versions of Python are:
 - 3.11
 - 3.12
 - 3.13
+- 3.14
 
 .. toctree::
     :hidden:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,6 @@ Under the hood, bindings are provided via `CFFI <https://cffi.readthedocs.io/en/
 
 Supported versions of Python are:
 
-- 3.9
 - 3.10
 - 3.11
 - 3.12

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
 
 [options]
 package_dir=

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,6 @@ classifiers =
     License :: OSI Approved :: BSD License
     Natural Language :: English
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12


### PR DESCRIPTION
Python 3.14 has been released, so add it to the test matrix.
And drop 3.9.