### PR TITLE
Fix ESAPI.hierarchy_control support for PLATFORM_NV hierarchy

### DIFF
--- a/src/tpm2_pytss/ESAPI.py
+++ b/src/tpm2_pytss/ESAPI.py
@@ -5227,7 +5227,12 @@ class ESAPI:
         _check_handle_type(
             enable,
             "enable",
-            expected=(ESYS_TR.ENDORSEMENT, ESYS_TR.OWNER, ESYS_TR.PLATFORM),
+            expected=(
+                ESYS_TR.ENDORSEMENT,
+                ESYS_TR.OWNER,
+                ESYS_TR.PLATFORM,
+                ESYS_TR.PLATFORM_NV,
+            ),
         )
         enable = ESAPI._fixup_hierarchy(enable)
 

--- a/src/tpm2_pytss/ESAPI.py
+++ b/src/tpm2_pytss/ESAPI.py
@@ -7397,10 +7397,11 @@ class ESAPI:
                 ESYS_TR.OWNER: TPM2_RH.OWNER,
                 ESYS_TR.PLATFORM: TPM2_RH.PLATFORM,
                 ESYS_TR.ENDORSEMENT: TPM2_RH.ENDORSEMENT,
+                ESYS_TR.PLATFORM_NV: TPM2_RH.PLATFORM_NV,
             }
             if hierarchy not in fixup_map:
                 raise RuntimeError(
-                    "Expected hierarchy to be one of ESYS_TR.NULL, ESYS_TR.PLATFORM, ESYS_TR.OWNER, ESYS_TR.ENDORSMENT"
+                    "Expected hierarchy to be one of ESYS_TR.NULL, ESYS_TR.PLATFORM, ESYS_TR.OWNER, ESYS_TR.ENDORSMENT, ESYS_TR.PLATFORM_NV"
                 )
 
             hierarchy = fixup_map[hierarchy]


### PR DESCRIPTION
The hierarchy_control function of ESAPI.py currently does not allow PLATFORM_NV as a valid hierarchy.

The PLATFORM_NV hierarchy is however an valid hierarchy to be enabled or disabled with Esys_HierarchyControl. 