### PR TITLE
utils: add public API to get EK templates

### DIFF
--- a/.ci/install-deps.sh
+++ b/.ci/install-deps.sh
@@ -5,6 +5,7 @@ set -exo pipefail
 
 export TPM2_TSS_VERSION=${TPM2_TSS_VERSION:-"3.0.3"}
 export TPM2_TSS_FAPI=${TPM2_TSS_FAPI:-"true"}
+export LIBTPMS=${LIBTPMS:-"v0.10.2"}
 
 #
 # Get dependencies for building and install tpm2-tss and abrmd projects
@@ -76,7 +77,7 @@ if pkg-config --exists tss2-tcti-swtpm; then
 
   # libtpms
   if ! pkg-config libtpms; then
-    git -C /tmp clone --depth=1 https://github.com/stefanberger/libtpms.git
+    git -C /tmp clone --depth=1 --branch "${LIBTPMS}" https://github.com/stefanberger/libtpms.git
     pushd /tmp/libtpms
     ./autogen.sh --prefix=/usr --with-openssl --with-tpm2 --without-tpm1
     make -j$(nproc)

--- a/src/tpm2_pytss/internal/templates.py
+++ b/src/tpm2_pytss/internal/templates.py
@@ -88,6 +88,10 @@ class ek_template:
         template = cls._templates.get(name, None)
         return template
 
+    @classmethod
+    def available_templates(cls) -> list[str]:
+        return cls._templates.keys()
+
 
 class ek_rsa2048(ek_template):
     _names = ("EK-RSA2048", "L-1")

--- a/src/tpm2_pytss/utils.py
+++ b/src/tpm2_pytss/utils.py
@@ -424,8 +424,8 @@ class ek_templates:
         return True
 
     @staticmethod
-    def keys(): -> list[str]:
-        return ek_template.available_templates
+    def keys() -> list[str]:
+        return ek_template.available_templates()
 
     @staticmethod
     def get(key: str, default=None) -> ek_template | Any:


### PR DESCRIPTION
Useful for when create_ek_template isn't a good fit.

Fixes #684