### PR TITLE
fix(crypto): fix ECC seed length calculation

### DIFF
--- a/src/tpm2_pytss/internal/crypto.py
+++ b/src/tpm2_pytss/internal/crypto.py
@@ -595,7 +595,8 @@ def __ecc_secret_to_seed(
     shared_key = key.exchange(ec.ECDH(), peer_public_key)
 
     pubnum = key.public_key().public_numbers()
-    xbytes = pubnum.x.to_bytes(key.key_size // 8, "big")
+    plength = ceil(key.curve.key_size / 8)
+    xbytes = pubnum.x.to_bytes(plength, "big")
     seed = kdfe(hashAlg, shared_key, label, exbytes, xbytes, halg.digest_size * 8)
     return seed
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -108,6 +108,15 @@ Qa6C2sTmPHlvWopRgWslXt1JmxbBKwWf2Q==
 -----END EC PRIVATE KEY-----
 """
 
+p521_parent_key = b"""-----BEGIN EC PRIVATE KEY-----
+MIHcAgEBBEIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOgBwYFK4EEACOhgYkDgYYABAGnPTUk
+Q94pGV3ZHWpktZWUebUqblsSPZq55a16ES16jdGtPxZKOkgyBR2mvRa1n+IbrrSQ
+hiwy6gWlkZ0u3jetfQE+mwO5ffpi3dmXn4bGyrgU8vFVf6gqnQMX0virH6NVzuwu
+LdTPjcV1sC1aztHew8cM8QXJvJOlkEJfWIyh7obA5Q==
+-----END EC PRIVATE KEY-----
+"""
+
 
 mkcred = b64decode(
     b"""
@@ -373,6 +382,35 @@ class TestUtils(TSS2_EsapiTest):
                 mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
             ),
         )
+
+        public = TPM2B_PUBLIC.from_pem(rsa_public_key)
+        sensitive = TPM2B_SENSITIVE.from_pem(rsa_private_key)
+
+        enckey, duplicate, outsymseed = wrap(
+            parent.publicArea, public, sensitive, b"", None
+        )
+
+        unwrapped_sensitive = unwrap(
+            parent.publicArea, parent_priv, public, duplicate, outsymseed
+        )
+
+        self.assertEqual(sensitive.marshal(), unwrapped_sensitive.marshal())
+
+    def test_unwrap_ec_p521_parent_rsa_child(self):
+
+        parent_priv = TPMT_SENSITIVE.from_pem(p521_parent_key, password=None)
+        parent = TPM2B_PUBLIC.from_pem(
+            p521_parent_key,
+            symmetric=TPMT_SYM_DEF_OBJECT(
+                algorithm=TPM2_ALG.AES,
+                keyBits=TPMU_SYM_KEY_BITS(aes=128),
+                mode=TPMU_SYM_MODE(aes=TPM2_ALG.CFB),
+            ),
+        )
+        self.assertEqual(
+            parent.publicArea.parameters.eccDetail.curveID, TPM2_ECC.NIST_P521
+        )
+        self.assertEqual(len(bytes(parent.publicArea.unique.ecc.x)), 66)
 
         public = TPM2B_PUBLIC.from_pem(rsa_public_key)
         sensitive = TPM2B_SENSITIVE.from_pem(rsa_private_key)


### PR DESCRIPTION
This pull request fixes ECC seed reconstruction for curves whose coordinate size is not a multiple of 8 bits, such as NIST P-521.

`_generate_ecc_seed()` uses `ceil(key.curve.key_size / 8)` when serialising ECC X/Y-coordinates for the KDFe context. However, `__ecc_secret_to_seed()` uses `key.key_size // 8` when serialising the private key's public X-coordinate.

For P-521, this truncates the expected coordinate length calculation to 65 bytes even though the coordinate may require 66 bytes. When the public X coordinate needs 66 bytes, seed reconstruction fails with:

```console
OverflowError: int too big to convert
```

This PR makes `__ecc_secret_to_seed()` use the same coordinate length calculation as `_generate_ecc_seed()`.

## PoC

https://gist.github.com/hyperfinitism/4812060765c358bd0e425b5443fe134a

## Expected output

### Before fix

```console
selected P-521 parent key
  attempts: 1
  curve.key_size: 521
  key.key_size // 8: 65
  ceil(curve.key_size / 8): 66
  parent public X bit length: 521
  parent public X byte length: 66

1. Direct _generate_ecc_seed() -> __ecc_secret_to_seed() check
  _generate_ecc_seed() produced seed length: 32
  encrypted seed TPMS_ECC_POINT length: 136
  __ecc_secret_to_seed() failed: OverflowError: int too big to convert

2. Public utils.wrap() -> utils.unwrap() check
  wrap() succeeded
  encrypted duplicate length: 172
  outsymseed length: 136
  unwrap() failed: OverflowError: int too big to convert
```

### After fix

```console
selected P-521 parent key
  attempts: 3
  curve.key_size: 521
  key.key_size // 8: 65
  ceil(curve.key_size / 8): 66
  parent public X bit length: 521
  parent public X byte length: 66

1. Direct _generate_ecc_seed() -> __ecc_secret_to_seed() check
  _generate_ecc_seed() produced seed length: 32
  encrypted seed TPMS_ECC_POINT length: 136
  recovered seed matches: True

2. Public utils.wrap() -> utils.unwrap() check
  wrap() succeeded
  encrypted duplicate length: 172
  outsymseed length: 136
  unwrap() matched original: True
```
