### PR TITLE
fix(fapi): keep callback output buffers alive

### DIFF
--- a/src/tpm2_pytss/FAPI.py
+++ b/src/tpm2_pytss/FAPI.py
@@ -124,6 +124,7 @@ class _FAPI_CB_UDATA:
         self.cur_exc = None
         self.udata = udata
         self.cb = cb
+        self.cdata_ref = None
 
 
 @ffi.def_extern()
@@ -139,7 +140,9 @@ def _fapi_auth_callback(object_path, description, auth, user_data):
         )
 
         auth_bytes = got_auth.decode() if isinstance(got_auth, str) else got_auth
-        auth[0] = _cffi_malloc("char[]", auth_bytes)
+        auth_cdata = _cffi_malloc("char[]", auth_bytes)
+        cb_udata.cdata_ref = auth_cdata
+        auth[0] = auth_cdata
     except Exception as e:
         rc = e.rc if isinstance(e, TSS2_Exception) else TSS2_RC.FAPI_RC_NOT_IMPLEMENTED
         cb_udata.cur_exc = e
@@ -196,7 +199,9 @@ def _fapi_sign_callback(
             cb_udata.udata,
         )
         signature_size[0] = len(sig)
-        signature[0] = _cffi_malloc("char[]", sig)
+        signature_cdata = _cffi_malloc("char[]", sig)
+        cb_udata.cdata_ref = signature_cdata
+        signature[0] = signature_cdata
     except Exception as e:
         rc = e.rc if isinstance(e, TSS2_Exception) else TSS2_RC.FAPI_RC_GENERAL_FAILURE
         cb_udata.cur_exc = e


### PR DESCRIPTION
This pull request fixes FAPI callback output buffer lifetime handling.

The auth and sign callbacks allocate CFFI buffers and pass their pointers back to FAPI. Those buffers need to remain alive after the Python callback returns, because FAPI consumes the returned pointers later in the call path.

This PR stores callback output cdata on the callback metadata object so that the buffers remain referenced for the required lifetime.

### Tests

Tested with Python 3.14.6 free-threaded (`3.14t`):

```bash
python3.14t -m pytest -q \
  test/test_fapi.py::TestFapiECC::test_policy_signed \
  test/test_fapi.py::TestFapiRSA::test_policy_signed \
  test/test_fapi.py::TestFapiRSA::test_policy_action \
  test/test_fapi.py::TestFapiRSA::test_sign \
  test/test_fapi.py::TestFapiRSA::test_get_tpm_blobs \
  test/test_fapi.py::TestFapiRSA::test_encrypt_decrypt
```

Before this fix, these FAPI PolicySigned tests would occasionally fail with a `TPM_RC_SIGNATURE` error:

```console
FAILED test/test_fapi.py::TestFapiRSA::test_policy_signed
tpm:parameter(5):the signature is not valid
```

After this fix, the same test set passes:

```console
6 passed
```