### PR TITLE
fix(fapi): fix memory leak in FAPI and tests

### DIFF
--- a/src/tpm2_pytss/FAPI.py
+++ b/src/tpm2_pytss/FAPI.py
@@ -540,7 +540,7 @@ class FAPI:
             self._ctx, path, ciphertext, len(ciphertext), plaintext, plaintext_size
         )
         _chkrc(ret)
-        return bytes(ffi.unpack(plaintext[0], plaintext_size[0]))
+        return bytes(ffi.unpack(_get_dptr(plaintext, lib.Fapi_Free), plaintext_size[0]))
 
     def create_seal(
         self,
@@ -869,15 +869,18 @@ class FAPI:
         )
         _chkrc(ret)
 
-        policy_str = ffi.string(policy[0]).decode(self.encoding)
+        policy_ptr = _get_dptr(policy, lib.Fapi_Free)
+        policy_str = ffi.string(policy_ptr).decode(self.encoding)
 
+        tpm_2b_public_ptr = _get_dptr(tpm_2b_public, lib.Fapi_Free)
         tpm_2b_public_buffer = bytes(
-            ffi.buffer(tpm_2b_public[0], tpm_2b_public_size[0])
+            ffi.buffer(tpm_2b_public_ptr, tpm_2b_public_size[0])
         )
         tpm_2b_public_unmarsh, _ = TPM2B_PUBLIC.unmarshal(tpm_2b_public_buffer)
 
+        tpm_2b_private_ptr = _get_dptr(tpm_2b_private, lib.Fapi_Free)
         tpm_2b_private_buffer = bytes(
-            ffi.buffer(tpm_2b_private[0], tpm_2b_private_size[0])
+            ffi.buffer(tpm_2b_private_ptr, tpm_2b_private_size[0])
         )
         tpm_2b_private_unmarsh, _ = TPM2B_PRIVATE.unmarshal(tpm_2b_private_buffer)
 

--- a/test/test_policy.py
+++ b/test/test_policy.py
@@ -15,6 +15,8 @@ from .TSS2_BaseTest import TSS2_EsapiTest
 if not _lib_version_atleast("tss2-policy", "4.0.0"):
     raise unittest.SkipTest("tss2-policy not installed or version is less then 4.0.0")
 
+from tpm2_pytss.policy import policy as policy
+
 
 def lowercase_dict(src):
     if not isinstance(src, dict):
@@ -124,18 +126,18 @@ class TestPolicy(TSS2_EsapiTest):
         def test():
             pass
 
-        p = policy(polstr, TPM2_ALG.SHA256)
-        p.set_callback(policy_cb_types.CALC_PCR, test)
-        cb = p._get_callback(policy_cb_types.CALC_PCR)
-        self.assertEqual(cb, test)
+        with policy(polstr, TPM2_ALG.SHA256) as p:
+            p.set_callback(policy_cb_types.CALC_PCR, test)
+            cb = p._get_callback(policy_cb_types.CALC_PCR)
+            self.assertEqual(cb, test)
 
-        p.set_callback(policy_cb_types.CALC_PCR, None)
-        cb = p._get_callback(policy_cb_types.CALC_PCR)
-        self.assertEqual(cb, None)
+            p.set_callback(policy_cb_types.CALC_PCR, None)
+            cb = p._get_callback(policy_cb_types.CALC_PCR)
+            self.assertEqual(cb, None)
 
-        with self.assertRaises(ValueError) as e:
-            p.set_callback(1234, test)
-        self.assertEqual(str(e.exception), "unsupported callback type 1234")
+            with self.assertRaises(ValueError) as e:
+                p.set_callback(1234, test)
+            self.assertEqual(str(e.exception), "unsupported callback type 1234")
 
     def test_calc_pcr_callback(self):
         pol = {

--- a/test/test_tcti.py
+++ b/test/test_tcti.py
@@ -118,11 +118,9 @@ class TestTCTI(TSS2_EsapiTest):
 
     def test_custom_pytcti_esapi(self):
 
-        t = MyTCTI(self.tcti)
-        e = ESAPI(t)
-        e.get_random(4)
-
-        e.startup(TPM2_SU.CLEAR)
+        with MyTCTI(self.tcti) as t, ESAPI(t) as e:
+            e.get_random(4)
+            e.startup(TPM2_SU.CLEAR)
 
     def test_custom_pytcti_C_wrapper_transmit_receive(self):
 
@@ -208,8 +206,7 @@ class TestTCTI(TSS2_EsapiTest):
             MyTCTI(None, b"THISISTOOBIG")
 
     def test_custom_pytcti_ctx_manager_finalize(self):
-        with MyTCTI(self.tcti) as t:
-            e = ESAPI(t)
+        with MyTCTI(self.tcti) as t, ESAPI(t) as e:
             r = e.get_random(4)
             self.assertEqual(len(r), 4)
             e.startup(TPM2_SU.CLEAR)


### PR DESCRIPTION
This pull request fixes native memory leaks in FAPI and tests:

- FAPI
  - `decrypt()`
  - `get_platform_certificate()`
  - `get_tpm_blobs()`)
- `test_policy.py`
  - `test_callbacks()`
- `test_tcti.py`
  - `test_custom_pytcti_esapi()`
  - `test_custom_pytcti_ctx_manager_finalize()`

For example, `Fapi_Decrypt()` returns the plaintext through a FAPI-allocated output buffer. The Python wrapper copied that buffer into `bytes`, but did not release the native allocation with `Fapi_Free()`. This caused every successful `FAPI.decrypt()` call to leak the decrypted plaintext buffer. This PR wraps the returned plaintext pointer with `_get_dptr(..., lib.Fapi_Free)` before unpacking it, matching the ownership handling already used by `FAPI.encrypt()` and other wrappers that receive FAPI-allocated output buffers.

## Reproduction (for FAPI_Decrypt)

### Code

- Gist: https://gist.github.com/hyperfinitism/5d4bc1d7c396f02a841fd32d4f137cd1
- `run_fapi_decrypt_valgrind.sh`
- `fapi_decrypt_leak_probe.py`

Download both files from the Gist into the `tpm2-pytss` repository root, then run the shell script from the repository root in an environment with `tpm2-pytss`, `swtpm`, `tss2-fapi`, `libtss2-tcti-swtpm`, and `valgrind` installed.

```sh
ITERATIONS=200 SIZE=128 LOG=/tmp/fapi-decrypt-valgrind.%p.log \
  bash ./run_fapi_decrypt_valgrind.sh
```

### Valgrind result before the fix

With `ITERATIONS=200 SIZE=128`, Valgrind reported an iteration-scaled definite leak from `Fapi_Decrypt_Finish`:

```text
==104== 25,600 bytes in 200 blocks are definitely lost in loss record 5,748 of 5,751
==104==    at 0x4848899: malloc
==104==    by 0x5AA7DEC: Fapi_Decrypt_Finish (in /usr/local/lib/libtss2-fapi.so.1.0.0)
==104==    by 0x5AA863D: Fapi_Decrypt (in /usr/local/lib/libtss2-fapi.so.1.0.0)
==104==    by 0x58F5ACA: _cffi_f_Fapi_Decrypt (tpm2_pytss._libtpm2_pytss.c:34176)
```

The `25,600 bytes in 200 blocks` leak matches `200` decrypt operations of a `128` byte plaintext.

Overall leak summary before this fix:

```text
==104== LEAK SUMMARY:
==104==    definitely lost: 30,226 bytes in 236 blocks
==104==    indirectly lost: 64 bytes in 1 blocks
==104==      possibly lost: 938,724 bytes in 8,886 blocks
==104==    still reachable: 222,964 bytes in 2,292 blocks
==104== ERROR SUMMARY: 34 errors from 34 contexts (suppressed: 0 from 0)
```

## Validation after the fix

The existing FAPI encrypt/decrypt test passes:

```sh
python3 -m pytest test/test_fapi.py::TestFapiRSA::test_encrypt_decrypt -q
```

```text
1 passed
```

After applying this fix and rerunning the shell script, the `Fapi_Decrypt_Finish` leak record is gone. The definite leak total drops by exactly `25,600` bytes and `200` blocks for `ITERATIONS=200 SIZE=128`, which confirms that the per-decrypt plaintext buffer is now released.

Before:

```text
definitely lost: 30,226 bytes in 236 blocks
```

After:

```text
definitely lost: 4,626 bytes in 36 blocks
```

## Follow-up proposal: add Valgrind job in CI

Existing tests cannot detect this type of errors. A Valgrind job in CI would help catch similar ownership bugs in CFFI wrappers. (Note added on Jul 7: PR #696 implements this CI job.)
