### PR TITLE
ci(valgrind): add Valgrind job to detect memory-related errors

### DIFF
--- a/.ci/install-deps.sh
+++ b/.ci/install-deps.sh
@@ -44,7 +44,8 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
     socat \
     libseccomp-dev \
     libjson-glib-dev \
-    libltdl-dev
+    libltdl-dev \
+    valgrind
 
 #
 # Install tpm2-tss

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -42,12 +42,57 @@ function run_publish_pkg() {
   python -m twine upload dist/*
 }
 
+function run_from_tmp() {
+  local status=0
+
+  # can't be in a directory that has the package as a folder, Python tries to
+  # use that over what's installed.
+  pushd /tmp || return "$?"
+  "$@" || status="$?"
+  popd || return "$?"
+
+  return "${status}"
+}
+
+function build_test_artifacts() {
+  # installs the deps so sdist and bdist work.
+  python3 -m pip install wheel $(./scripts/get_deps.py) || return "$?"
+
+  python3 setup.py sdist || return "$?"
+  python3 setup.py bdist || return "$?"
+}
+
+function check_user_install() {
+  local runner="$1"
+
+  git clean -fdx || return "$?"
+  python3 -m pip install --user . || return "$?"
+  run_from_tmp "${runner}" python3 -c 'import tpm2_pytss' || return "$?"
+}
+
+function check_wheel_install() {
+  local runner="$1"
+  shift
+
+  git clean -fdx || return "$?"
+  python3 -m pip uninstall --yes tpm2-pytss || return "$?"
+  python3 -Bm build --no-isolation || return "$?"
+  python3 -m installer --destdir=installation dist/*.whl || return "$?"
+
+  local site_packages
+  site_packages=$(realpath $(find . -type d -name site-packages)) || return "$?"
+  export PYTHONPATH="${site_packages}"
+
+  local totest
+  totest=$(realpath test/test_esapi.py) || return "$?"
+
+  run_from_tmp "${runner}" python3 -c 'import tpm2_pytss' || return "$?"
+  run_from_tmp "${runner}" "$@" "${totest}" -k test_get_random || return "$?"
+}
+
 function run_test() {
 
-  # installs the deps so sdist and bdist work.
-  python3 -m pip install wheel $(./scripts/get_deps.py)
-
-  python3 setup.py sdist && python3 setup.py bdist
+  build_test_artifacts
 
   python3 -m pytest -n $(nproc) --cov=tpm2_pytss -v
 
@@ -55,33 +100,12 @@ function run_test() {
     python3 -m coverage xml -o /tmp/coverage.xml
   fi
 
-  # verify that package is sane on a user install that is not editable
-  git clean -fdx
-  python3 -m pip install --user .
-  # can't be in a directory that has the package as a folder, Python tries to use that
-  # over whats installed.
-  pushd /tmp
-  python3 -c 'import tpm2_pytss'
-  popd
+  function run_command() {
+    "$@"
+  }
 
-  # verify wheel build works
-  git clean -fdx
-  python3 -m pip uninstall --yes tpm2-pytss
-  python3 -Bm build --no-isolation
-  python3 -m installer --destdir=installation dist/*.whl
-  # find site-packages
-  site_packages=$(realpath $(find . -type d -name site-packages))
-  export PYTHONPATH="${site_packages}"
-  totest=$(realpath test/test_esapi.py)
-  pushd /tmp
-
-  # ensure module imports OK
-  python3 -c 'import tpm2_pytss'
-
-  # ensure a test suite can run, but don't run the whole thing and slow down the CI since
-  # we already ran the tests.
-  pytest "$totest" -k test_get_random
-  popd
+  check_user_install run_command
+  check_wheel_install run_command pytest
 }
 
 function run_whitespace() {
@@ -107,6 +131,66 @@ function run_lint() {
   ruff check "${SRC_ROOT}"
 }
 
+function run_valgrind() {
+  local valgrind_log_dir="${VALGRIND_LOG_DIR:-/tmp/tpm2-pytss-valgrind}"
+  local valgrind_error_exitcode="${VALGRIND_ERROR_EXITCODE:-42}"
+  local valgrind_errors_for_leak_kinds="${VALGRIND_ERRORS_FOR_LEAK_KINDS:-definite}"
+  local pytest_args=()
+  local valgrind_args=(
+    --tool=memcheck
+    --leak-check=full
+    --show-leak-kinds=all
+    --errors-for-leak-kinds="${valgrind_errors_for_leak_kinds}"
+    --error-exitcode="${valgrind_error_exitcode}"
+    --track-origins=yes
+    --expensive-definedness-checks=yes
+    --num-callers=40
+    --trace-children="${VALGRIND_TRACE_CHILDREN:-no}"
+    --log-file="${valgrind_log_dir}/tpm2-pytss-valgrind.%p.log"
+  )
+
+  if [ -n "${VALGRIND_PYTEST_ARGS:-}" ]; then
+    pytest_args=(${VALGRIND_PYTEST_ARGS})
+  fi
+
+  if [ -n "${VALGRIND_EXTRA_ARGS:-}" ]; then
+    valgrind_args+=(${VALGRIND_EXTRA_ARGS})
+  fi
+
+  mkdir -p "${valgrind_log_dir}"
+  find "${valgrind_log_dir}" -type f -name '*.log' -delete
+
+  function print_valgrind_summary() {
+    find "${valgrind_log_dir}" -type f -name '*.log' -print -exec grep -Hn -E \
+      'LEAK SUMMARY|definitely lost|indirectly lost|possibly lost|still reachable|ERROR SUMMARY' \
+      {} \; || true
+  }
+
+  function run_memcheck() {
+    set +e
+    PYTHONMALLOC=malloc valgrind "${valgrind_args[@]}" "$@"
+    local valgrind_status="$?"
+    set -e
+
+    if [ "${valgrind_status}" -ne 0 ]; then
+      print_valgrind_summary
+    fi
+
+    return "${valgrind_status}"
+  }
+
+  # Match the normal test setup/build flow, but run the Python code under
+  # Valgrind without xdist or coverage so Memcheck observes one process.
+  build_test_artifacts
+
+  run_memcheck python3 -m pytest -v "${pytest_args[@]}" || return "$?"
+
+  check_user_install run_memcheck
+  check_wheel_install run_memcheck python3 -m pytest
+
+  print_valgrind_summary
+}
+
 if [ "x${TEST}" != "x" ]; then
   run_test
 elif [ "x${WHITESPACE}" != "x" ]; then
@@ -117,4 +201,6 @@ elif [ "x${PUBLISH_PKG}" != "x" ]; then
   run_publish_pkg
 elif [ "x${LINT}" != "x" ]; then
   run_lint
+elif [ "x${VALGRIND}" != "x" ]; then
+  run_valgrind
 fi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -110,3 +110,38 @@ jobs:
       env:
         LINT: 1
       run: ./.ci/run.sh
+
+  valgrind:
+    runs-on: ubuntu-latest
+    # Keep this advisory until all definite leaks are fixed.
+    continue-on-error: true
+    timeout-minutes: 120
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v6
+
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v6
+      with:
+        python-version: 3.x
+
+    - name: Install dependencies
+      env:
+        TPM2_TSS_VERSION: 4.1.3
+        TPM2_TSS_FAPI: true
+        VALGRIND: 1
+      run: ./.ci/install-deps.sh
+
+    - name: Check
+      env:
+        VALGRIND: 1
+        VALGRIND_LOG_DIR: /tmp/tpm2-pytss-valgrind
+      run: ./.ci/run.sh
+
+    - name: Upload Valgrind logs
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: valgrind-logs
+        path: /tmp/tpm2-pytss-valgrind/*.log
+        if-no-files-found: ignore


### PR DESCRIPTION
This PR adds the CI jobs that runs the normal pytest/build/install checks under Valgrind Memcheck and uploads Valgrind logs as workflow artifacts.

Once all the existing leaks are resolved, this PR will be ready to be merged.
